### PR TITLE
fix: use chart-level symbol as OHLC legend label instead of generic "…

### DIFF
--- a/src/api/chart-api.ts
+++ b/src/api/chart-api.ts
@@ -2596,7 +2596,7 @@ class ChartApi implements IChartApi {
     const hudRowId = `series-${type}-${seriesIndex}`;
     hud.addRow({
       id: hudRowId,
-      label: (resolvedOptions.label as string) || 'Symbol',
+      label: (resolvedOptions.label as string) || this._options.symbol || 'Symbol',
       color: this._getSeriesColor(type, resolvedOptions),
       getValues: (barIndex: number) => this._getSeriesValues(api, barIndex),
       onToggleVisible: () => {

--- a/src/api/options.ts
+++ b/src/api/options.ts
@@ -81,6 +81,7 @@ export interface TimeGapsOptions {
 }
 
 export interface ChartOptions {
+  symbol?: string;
   width: number;
   height: number;
   autoSize: boolean;


### PR DESCRIPTION
…Symbol"

Add optional `symbol` field to ChartOptions so the OHLC legend displays the actual ticker (e.g. "AAPL") instead of the hardcoded "Symbol" fallback.