### PR TITLE
fix: add symbol option to all Storybook stories so OHLC legend shows …

### DIFF
--- a/stories/AllChartTypes.stories.ts
+++ b/stories/AllChartTypes.stories.ts
@@ -56,7 +56,7 @@ export const Overview: Story = {
         code: `
 import { createChart } from 'fin-charter';
 
-const chart = createChart(document.getElementById('chart'), { autoSize: true });
+const chart = createChart(document.getElementById('chart'), { autoSize: true, symbol: 'AAPL' });
 
 // Candlestick
 chart.addCandlestickSeries().setData(data);
@@ -99,7 +99,7 @@ chart.addBaselineSeries().setData(data);
         title: 'Candlestick',
         color: '#22AB94',
         create: (el) => {
-          const chart = createChart(el, { autoSize: true });
+          const chart = createChart(el, { autoSize: true, symbol: 'AAPL' });
           chart.addCandlestickSeries().setData(bars);
         },
       },
@@ -107,7 +107,7 @@ chart.addBaselineSeries().setData(data);
         title: 'Hollow Candle',
         color: '#00e5ff',
         create: (el) => {
-          const chart = createChart(el, { autoSize: true });
+          const chart = createChart(el, { autoSize: true, symbol: 'AAPL' });
           chart.addHollowCandleSeries().setData(bars);
         },
       },
@@ -115,7 +115,7 @@ chart.addBaselineSeries().setData(data);
         title: 'OHLC Bar',
         color: '#f4c430',
         create: (el) => {
-          const chart = createChart(el, { autoSize: true });
+          const chart = createChart(el, { autoSize: true, symbol: 'AAPL' });
           chart.addBarSeries().setData(bars);
         },
       },
@@ -123,7 +123,7 @@ chart.addBaselineSeries().setData(data);
         title: 'Line',
         color: '#9c27b0',
         create: (el) => {
-          const chart = createChart(el, { autoSize: true });
+          const chart = createChart(el, { autoSize: true, symbol: 'AAPL' });
           chart.addLineSeries({ color: '#9c27b0', lineWidth: 2 }).setData(bars);
         },
       },
@@ -131,7 +131,7 @@ chart.addBaselineSeries().setData(data);
         title: 'Area',
         color: '#ff9800',
         create: (el) => {
-          const chart = createChart(el, { autoSize: true });
+          const chart = createChart(el, { autoSize: true, symbol: 'AAPL' });
           chart.addAreaSeries({
             lineColor: '#ff9800',
             topColor: 'rgba(255, 152, 0, 0.4)',
@@ -143,7 +143,7 @@ chart.addBaselineSeries().setData(data);
         title: 'Baseline',
         color: '#e91e63',
         create: (el) => {
-          const chart = createChart(el, { autoSize: true });
+          const chart = createChart(el, { autoSize: true, symbol: 'AAPL' });
           chart.addBaselineSeries().setData(bars);
         },
       },

--- a/stories/AreaChart.stories.ts
+++ b/stories/AreaChart.stories.ts
@@ -25,7 +25,7 @@ export const Default: Story = {
         code: `
 import { createChart } from 'fin-charter';
 
-const chart = createChart(document.getElementById('chart'), { autoSize: true });
+const chart = createChart(document.getElementById('chart'), { autoSize: true, symbol: 'AAPL' });
 const series = chart.addAreaSeries();
 series.setData(data);
 `.trim(),
@@ -34,7 +34,7 @@ series.setData(data);
   },
   render: () => {
     const container = createChartContainer();
-    const chart = createChart(container, { autoSize: true });
+    const chart = createChart(container, { autoSize: true, symbol: 'AAPL' });
     const series = chart.addAreaSeries();
     series.setData(AAPL_DAILY);
     return container;
@@ -59,7 +59,7 @@ series.setData(data);
   },
   render: () => {
     const container = createChartContainer();
-    const chart = createChart(container, { autoSize: true });
+    const chart = createChart(container, { autoSize: true, symbol: 'AAPL' });
     const series = chart.addAreaSeries({
       lineColor: '#00e5ff',
       topColor: 'rgba(0, 229, 255, 0.4)',

--- a/stories/BarChart.stories.ts
+++ b/stories/BarChart.stories.ts
@@ -25,7 +25,7 @@ export const Default: Story = {
         code: `
 import { createChart } from 'fin-charter';
 
-const chart = createChart(document.getElementById('chart'), { autoSize: true });
+const chart = createChart(document.getElementById('chart'), { autoSize: true, symbol: 'AAPL' });
 const series = chart.addBarSeries();
 series.setData(data);
 `.trim(),
@@ -34,7 +34,7 @@ series.setData(data);
   },
   render: () => {
     const container = createChartContainer();
-    const chart = createChart(container, { autoSize: true });
+    const chart = createChart(container, { autoSize: true, symbol: 'AAPL' });
     const series = chart.addBarSeries();
     series.setData(AAPL_DAILY);
     return container;
@@ -58,7 +58,7 @@ series.setData(data);
   },
   render: () => {
     const container = createChartContainer();
-    const chart = createChart(container, { autoSize: true });
+    const chart = createChart(container, { autoSize: true, symbol: 'AAPL' });
     const series = chart.addBarSeries({
       upColor: '#22AB94',
       downColor: '#F7525F',

--- a/stories/BaselineChart.stories.ts
+++ b/stories/BaselineChart.stories.ts
@@ -26,7 +26,7 @@ export const Default: Story = {
         code: `
 import { createChart } from 'fin-charter';
 
-const chart = createChart(document.getElementById('chart'), { autoSize: true });
+const chart = createChart(document.getElementById('chart'), { autoSize: true, symbol: 'AAPL' });
 const series = chart.addBaselineSeries();
 series.setData(data);
 `.trim(),
@@ -35,7 +35,7 @@ series.setData(data);
   },
   render: () => {
     const container = createChartContainer();
-    const chart = createChart(container, { autoSize: true });
+    const chart = createChart(container, { autoSize: true, symbol: 'AAPL' });
     const series = chart.addBaselineSeries();
     series.setData(AAPL_DAILY);
     return container;
@@ -62,7 +62,7 @@ series.setData(data);
   },
   render: () => {
     const container = createChartContainer();
-    const chart = createChart(container, { autoSize: true });
+    const chart = createChart(container, { autoSize: true, symbol: 'AAPL' });
     const series = chart.addBaselineSeries({
       basePrice: 110,
       topLineColor: '#00e5ff',

--- a/stories/CandlestickChart.stories.ts
+++ b/stories/CandlestickChart.stories.ts
@@ -24,7 +24,7 @@ export const Default: Story = {
       source: {
         code: `import { createChart } from 'fin-charter';
 
-const chart = createChart(document.getElementById('chart'), { autoSize: true });
+const chart = createChart(document.getElementById('chart'), { autoSize: true, symbol: 'AAPL' });
 const series = chart.addCandlestickSeries();
 series.setData(data); // Array of { time, open, high, low, close, volume }`,
       },
@@ -32,7 +32,7 @@ series.setData(data); // Array of { time, open, high, low, close, volume }`,
   },
   render: () => {
     const container = createChartContainer();
-    const chart = createChart(container, { autoSize: true });
+    const chart = createChart(container, { autoSize: true, symbol: 'AAPL' });
     const series = chart.addCandlestickSeries();
     series.setData(AAPL_DAILY);
     return container;
@@ -56,7 +56,7 @@ series.setData(data);`,
   },
   render: () => {
     const container = createChartContainer();
-    const chart = createChart(container, { autoSize: true });
+    const chart = createChart(container, { autoSize: true, symbol: 'AAPL' });
     const series = chart.addCandlestickSeries({
       upColor: '#00e5ff',
       downColor: '#ff4081',
@@ -80,7 +80,7 @@ series.setData(data.slice(0, 20)); // Only 20 bars`,
   },
   render: () => {
     const container = createChartContainer();
-    const chart = createChart(container, { autoSize: true });
+    const chart = createChart(container, { autoSize: true, symbol: 'AAPL' });
     const series = chart.addCandlestickSeries();
     series.setData(generateOHLCV(20));
     return container;
@@ -94,6 +94,7 @@ export const WithoutLastPriceLine: Story = {
       source: {
         code: `const chart = createChart(container, {
   autoSize: true,
+  symbol: 'AAPL',
   lastPriceLine: { visible: false },
 });
 const series = chart.addCandlestickSeries();
@@ -103,7 +104,7 @@ series.setData(data);`,
   },
   render: () => {
     const container = createChartContainer();
-    const chart = createChart(container, { autoSize: true, lastPriceLine: { visible: false } });
+    const chart = createChart(container, { autoSize: true, symbol: 'AAPL', lastPriceLine: { visible: false } });
     const series = chart.addCandlestickSeries();
     series.setData(AAPL_DAILY);
     return container;

--- a/stories/Customization/CustomFonts.stories.ts
+++ b/stories/Customization/CustomFonts.stories.ts
@@ -28,6 +28,7 @@ export const Monospace: Story = {
 
 const chart = createChart(container, {
   autoSize: true,
+  symbol: 'AAPL',
   layout: {
     fontFamily: '"Courier New", Courier, monospace',
     fontSize: 11,
@@ -40,6 +41,7 @@ const chart = createChart(container, {
     const container = createChartContainer();
     const chart = createChart(container, {
       autoSize: true,
+      symbol: 'AAPL',
       layout: {
         fontFamily: '"Courier New", Courier, monospace',
         fontSize: 11,
@@ -58,6 +60,7 @@ export const SystemSansSerif: Story = {
       source: {
         code: `const chart = createChart(container, {
   autoSize: true,
+  symbol: 'AAPL',
   layout: {
     fontFamily: '-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif',
     fontSize: 12,
@@ -70,6 +73,7 @@ export const SystemSansSerif: Story = {
     const container = createChartContainer();
     const chart = createChart(container, {
       autoSize: true,
+      symbol: 'AAPL',
       layout: {
         fontFamily: '-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif',
         fontSize: 12,
@@ -88,6 +92,7 @@ export const LargeFontSize: Story = {
       source: {
         code: `const chart = createChart(container, {
   autoSize: true,
+  symbol: 'AAPL',
   layout: { fontSize: 14 },
 });`,
       },
@@ -97,6 +102,7 @@ export const LargeFontSize: Story = {
     const container = createChartContainer();
     const chart = createChart(container, {
       autoSize: true,
+      symbol: 'AAPL',
       layout: {
         fontFamily: '-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif',
         fontSize: 14,

--- a/stories/Customization/DualPriceScales.stories.ts
+++ b/stories/Customization/DualPriceScales.stories.ts
@@ -41,6 +41,7 @@ export const Default: Story = {
 
 const chart = createChart(container, {
   autoSize: true,
+  symbol: 'AAPL',
   rightPriceScale: { visible: true },
   leftPriceScale: { visible: true },
 });
@@ -54,6 +55,7 @@ chart.addLineSeries({ color: '#f4c430', priceScaleId: 'left' });`,
     const container = createChartContainer();
     const chart = createChart(container, {
       autoSize: true,
+      symbol: 'AAPL',
       rightPriceScale: { visible: true },
       leftPriceScale: { visible: true },
     });
@@ -79,6 +81,7 @@ export const RightOnly: Story = {
       source: {
         code: `const chart = createChart(container, {
   autoSize: true,
+  symbol: 'AAPL',
   rightPriceScale: { visible: true },
   leftPriceScale: { visible: false },
 });`,
@@ -89,6 +92,7 @@ export const RightOnly: Story = {
     const container = createChartContainer();
     const chart = createChart(container, {
       autoSize: true,
+      symbol: 'AAPL',
       rightPriceScale: { visible: true },
       leftPriceScale: { visible: false },
     });
@@ -105,6 +109,7 @@ export const LeftOnly: Story = {
       source: {
         code: `const chart = createChart(container, {
   autoSize: true,
+  symbol: 'AAPL',
   rightPriceScale: { visible: false },
   leftPriceScale: { visible: true },
 });`,
@@ -115,6 +120,7 @@ export const LeftOnly: Story = {
     const container = createChartContainer();
     const chart = createChart(container, {
       autoSize: true,
+      symbol: 'AAPL',
       rightPriceScale: { visible: false },
       leftPriceScale: { visible: true },
     });

--- a/stories/Customization/PriceFormatter.stories.ts
+++ b/stories/Customization/PriceFormatter.stories.ts
@@ -28,6 +28,7 @@ export const CurrencyFormat: Story = {
 
 const chart = createChart(container, {
   autoSize: true,
+  symbol: 'AAPL',
   priceFormatter: (price) => \`$\${price.toFixed(2)}\`,
 });`,
       },
@@ -37,6 +38,7 @@ const chart = createChart(container, {
     const container = createChartContainer();
     const chart = createChart(container, {
       autoSize: true,
+      symbol: 'AAPL',
       priceFormatter: (price: number) => `$${price.toFixed(2)}`,
     });
     const series = chart.addCandlestickSeries();
@@ -52,6 +54,7 @@ export const CompactFormat: Story = {
       source: {
         code: `const chart = createChart(container, {
   autoSize: true,
+  symbol: 'AAPL',
   priceFormatter: (price) => {
     if (price >= 1_000_000) return \`\${(price / 1_000_000).toFixed(2)}M\`;
     if (price >= 1_000) return \`\${(price / 1_000).toFixed(1)}K\`;
@@ -65,6 +68,7 @@ export const CompactFormat: Story = {
     const container = createChartContainer();
     const chart = createChart(container, {
       autoSize: true,
+      symbol: 'AAPL',
       priceFormatter: (price: number) => {
         if (price >= 1_000_000) return `${(price / 1_000_000).toFixed(2)}M`;
         if (price >= 1_000) return `${(price / 1_000).toFixed(1)}K`;
@@ -84,6 +88,7 @@ export const BasisPoints: Story = {
       source: {
         code: `const chart = createChart(container, {
   autoSize: true,
+  symbol: 'AAPL',
   priceFormatter: (price) => \`\${(price * 100).toFixed(0)} bps\`,
 });`,
       },
@@ -93,6 +98,7 @@ export const BasisPoints: Story = {
     const container = createChartContainer();
     const chart = createChart(container, {
       autoSize: true,
+      symbol: 'AAPL',
       priceFormatter: (price: number) => `${(price * 100).toFixed(0)} bps`,
     });
     const series = chart.addLineSeries({ color: '#9c27b0', lineWidth: 2 });

--- a/stories/Customization/Themes.stories.ts
+++ b/stories/Customization/Themes.stories.ts
@@ -26,14 +26,14 @@ export const Dark: Story = {
       source: {
         code: `import { createChart, DARK_THEME } from 'fin-charter';
 
-const chart = createChart(container, { autoSize: true, theme: 'dark' });
+const chart = createChart(container, { autoSize: true, symbol: 'AAPL', theme: 'dark' });
 chart.applyOptions(DARK_THEME);`,
       },
     },
   },
   render: () => {
     const container = createChartContainer();
-    const chart = createChart(container, { autoSize: true, theme: 'dark' });
+    const chart = createChart(container, { autoSize: true, symbol: 'AAPL', theme: 'dark' });
     chart.applyOptions(DARK_THEME);
     const series = chart.addCandlestickSeries();
     series.setData(AAPL_DAILY);
@@ -46,7 +46,7 @@ export const Light: Story = {
   parameters: {
     docs: {
       source: {
-        code: `const chart = createChart(container, { autoSize: true, theme: 'light' });
+        code: `const chart = createChart(container, { autoSize: true, symbol: 'AAPL', theme: 'light' });
 chart.applyOptions(LIGHT_THEME);
 chart.addCandlestickSeries({
   upColor: '#22AB94', downColor: '#F7525F',
@@ -57,7 +57,7 @@ chart.addCandlestickSeries({
   },
   render: () => {
     const container = createChartContainer();
-    const chart = createChart(container, { autoSize: true, theme: 'light' });
+    const chart = createChart(container, { autoSize: true, symbol: 'AAPL', theme: 'light' });
     chart.applyOptions(LIGHT_THEME);
     const series = chart.addCandlestickSeries({
       upColor: '#22AB94',
@@ -75,7 +75,7 @@ export const Colorful: Story = {
   parameters: {
     docs: {
       source: {
-        code: `const chart = createChart(container, { autoSize: true, theme: 'colorful' });
+        code: `const chart = createChart(container, { autoSize: true, symbol: 'AAPL', theme: 'colorful' });
 chart.applyOptions(COLORFUL_THEME);
 chart.addCandlestickSeries({
   upColor: '#00c176', downColor: '#ff4a68',
@@ -86,7 +86,7 @@ chart.addCandlestickSeries({
   },
   render: () => {
     const container = createChartContainer();
-    const chart = createChart(container, { autoSize: true, theme: 'colorful' });
+    const chart = createChart(container, { autoSize: true, symbol: 'AAPL', theme: 'colorful' });
     chart.applyOptions(COLORFUL_THEME);
     const series = chart.addCandlestickSeries({
       upColor: '#00c176',

--- a/stories/Features/ChartState.stories.ts
+++ b/stories/Features/ChartState.stories.ts
@@ -28,7 +28,7 @@ export const SaveRestore: Story = {
       source: {
         code: `import { createChart } from 'fin-charter';
 
-const chart = createChart(container, { autoSize: true });
+const chart = createChart(container, { autoSize: true, symbol: 'AAPL' });
 const series = chart.addCandlestickSeries();
 series.setData(data);
 
@@ -76,7 +76,7 @@ await chart.importState(JSON.parse(json), async (seriesId) => {
 
     // Chart
     const container = createChartContainer();
-    const chart = createChart(container, { autoSize: true });
+    const chart = createChart(container, { autoSize: true, symbol: 'AAPL' });
     const series = chart.addCandlestickSeries();
     series.setData(AAPL_DAILY);
 

--- a/stories/Features/ComparisonMode.stories.ts
+++ b/stories/Features/ComparisonMode.stories.ts
@@ -27,7 +27,7 @@ export const CompareSymbols: Story = {
       source: {
         code: `import { createChart } from 'fin-charter';
 
-const chart = createChart(container, { autoSize: true });
+const chart = createChart(container, { autoSize: true, symbol: 'AAPL' });
 const mainSeries = chart.addCandlestickSeries();
 mainSeries.setData(aaplData);
 
@@ -70,7 +70,7 @@ compSeries.setData(msftData);`,
     toolbar.appendChild(legendEl);
 
     const container = createChartContainer();
-    const chart = createChart(container, { autoSize: true });
+    const chart = createChart(container, { autoSize: true, symbol: 'AAPL' });
 
     const mainSeries = chart.addCandlestickSeries({
       upColor: '#22AB94',

--- a/stories/Features/DataChanged.stories.ts
+++ b/stories/Features/DataChanged.stories.ts
@@ -27,7 +27,7 @@ export const DataChangedCounter: Story = {
       source: {
         code: `import { createChart } from 'fin-charter';
 
-const chart = createChart(container, { autoSize: true });
+const chart = createChart(container, { autoSize: true, symbol: 'AAPL' });
 const series = chart.addCandlestickSeries();
 series.setData(data);
 
@@ -52,7 +52,7 @@ series.update({ time, open, high, low, close, volume });`,
     counter.textContent = 'Data change events: 0';
 
     const container = createChartContainer();
-    const chart = createChart(container, { autoSize: true });
+    const chart = createChart(container, { autoSize: true, symbol: 'AAPL' });
 
     const series = chart.addCandlestickSeries();
     series.setData(AAPL_DAILY);

--- a/stories/Features/DrawingTools.stories.ts
+++ b/stories/Features/DrawingTools.stories.ts
@@ -37,7 +37,7 @@ export const InteractiveDrawing: Story = {
       source: {
         code: `import { createChart } from 'fin-charter';
 
-const chart = createChart(container, { autoSize: true });
+const chart = createChart(container, { autoSize: true, symbol: 'AAPL' });
 const series = chart.addCandlestickSeries();
 series.setData(data);
 
@@ -61,7 +61,7 @@ chart.setActiveDrawingTool(null);`,
     status.textContent = 'No tool active — click a tool to start drawing';
 
     const container = createChartContainer();
-    const chart = createChart(container, { autoSize: true });
+    const chart = createChart(container, { autoSize: true, symbol: 'AAPL' });
     const series = chart.addCandlestickSeries();
     series.setData(AAPL_DAILY);
 
@@ -115,7 +115,7 @@ chart.addDrawing('trendline',
   },
   render: () => {
     const container = createChartContainer();
-    const chart = createChart(container, { autoSize: true });
+    const chart = createChart(container, { autoSize: true, symbol: 'AAPL' });
     const series = chart.addCandlestickSeries();
     series.setData(AAPL_DAILY);
 

--- a/stories/Features/EventMarkers.stories.ts
+++ b/stories/Features/EventMarkers.stories.ts
@@ -27,7 +27,7 @@ export const CorporateEvents: Story = {
       source: {
         code: `import { createChart } from 'fin-charter';
 
-const chart = createChart(container, { autoSize: true });
+const chart = createChart(container, { autoSize: true, symbol: 'AAPL' });
 const series = chart.addCandlestickSeries();
 series.setData(data);
 
@@ -48,7 +48,7 @@ series.setEvents([
   },
   render: () => {
     const container = createChartContainer();
-    const chart = createChart(container, { autoSize: true });
+    const chart = createChart(container, { autoSize: true, symbol: 'AAPL' });
     const series = chart.addCandlestickSeries();
     series.setData(AAPL_DAILY);
 

--- a/stories/Features/ExtendedHours.stories.ts
+++ b/stories/Features/ExtendedHours.stories.ts
@@ -61,7 +61,7 @@ export const MarketSessions: Story = {
       source: {
         code: `import { createChart, US_EQUITY_SESSIONS } from 'fin-charter';
 
-const chart = createChart(container, { autoSize: true });
+const chart = createChart(container, { autoSize: true, symbol: 'AAPL' });
 chart.setMarketSessions(US_EQUITY_SESSIONS);
 chart.setPeriodicity({ interval: 5, unit: 'minute' });
 
@@ -111,7 +111,7 @@ chart.setSessionFilter('regular');`,
     toolbar.appendChild(label);
 
     const container = createChartContainer();
-    const chart = createChart(container, { autoSize: true });
+    const chart = createChart(container, { autoSize: true, symbol: 'AAPL' });
 
     // Apply US equity sessions
     chart.setMarketSessions(US_EQUITY_SESSIONS);

--- a/stories/Features/FitContent.stories.ts
+++ b/stories/Features/FitContent.stories.ts
@@ -28,6 +28,7 @@ export const FitContentDemo: Story = {
 
 const chart = createChart(container, {
   autoSize: true,
+  symbol: 'AAPL',
   timeScale: { barSpacing: 2 },
 });
 const series = chart.addCandlestickSeries();
@@ -52,6 +53,7 @@ chart.fitContent();`,
     const container = createChartContainer();
     const chart = createChart(container, {
       autoSize: true,
+      symbol: 'AAPL',
       timeScale: { barSpacing: 2 },
     });
 

--- a/stories/Features/HUD.stories.ts
+++ b/stories/Features/HUD.stories.ts
@@ -26,7 +26,7 @@ export const FullHUD: Story = {
       source: {
         code: `import { createChart } from 'fin-charter';
 
-const chart = createChart(container, { autoSize: true });
+const chart = createChart(container, { autoSize: true, symbol: 'AAPL' });
 const series = chart.addCandlestickSeries({ label: 'AAPL' });
 series.setData(data);
 
@@ -42,7 +42,7 @@ chart.addIndicator('rsi', {
   render: () => {
     const container = createChartContainer();
     container.style.height = '700px';
-    const chart = createChart(container, { autoSize: true });
+    const chart = createChart(container, { autoSize: true, symbol: 'AAPL' });
 
     const candleSeries = chart.addCandlestickSeries({ label: 'AAPL' });
     candleSeries.setData(AAPL_DAILY);

--- a/stories/Features/HeikinAshi.stories.ts
+++ b/stories/Features/HeikinAshi.stories.ts
@@ -27,7 +27,7 @@ export const HeikinAshiChart: Story = {
       source: {
         code: `import { createChart } from 'fin-charter';
 
-const chart = createChart(container, { autoSize: true });
+const chart = createChart(container, { autoSize: true, symbol: 'AAPL' });
 const series = chart.addHeikinAshiSeries({
   upColor: '#22AB94',
   downColor: '#F7525F',
@@ -38,7 +38,7 @@ series.setData(data);`,
   },
   render: () => {
     const container = createChartContainer();
-    const chart = createChart(container, { autoSize: true });
+    const chart = createChart(container, { autoSize: true, symbol: 'AAPL' });
 
     const series = chart.addHeikinAshiSeries({
       upColor: '#22AB94',

--- a/stories/Features/IndicatorPanes.stories.ts
+++ b/stories/Features/IndicatorPanes.stories.ts
@@ -25,7 +25,7 @@ export const RSIAndMACD: Story = {
       source: {
         code: `import { createChart } from 'fin-charter';
 
-const chart = createChart(container, { autoSize: true });
+const chart = createChart(container, { autoSize: true, symbol: 'AAPL' });
 const series = chart.addCandlestickSeries();
 series.setData(data);
 
@@ -42,7 +42,7 @@ chart.addIndicator('macd', {
   },
   render: () => {
     const container = createChartContainer();
-    const chart = createChart(container, { autoSize: true });
+    const chart = createChart(container, { autoSize: true, symbol: 'AAPL' });
 
     const candleSeries = chart.addCandlestickSeries();
     candleSeries.setData(AAPL_DAILY);
@@ -96,7 +96,7 @@ chart.addIndicator('adx', { source: series, params: { period: 14 }, label: 'ADX'
   render: () => {
     const container = createChartContainer();
     container.style.height = '800px';
-    const chart = createChart(container, { autoSize: true });
+    const chart = createChart(container, { autoSize: true, symbol: 'AAPL' });
 
     const candleSeries = chart.addCandlestickSeries();
     candleSeries.setData(AAPL_DAILY);

--- a/stories/Features/LastPriceLine.stories.ts
+++ b/stories/Features/LastPriceLine.stories.ts
@@ -29,6 +29,7 @@ export const Visible: Story = {
 
 const chart = createChart(container, {
   autoSize: true,
+  symbol: 'AAPL',
   lastPriceLine: { visible: true },
 });
 const series = chart.addCandlestickSeries();
@@ -40,6 +41,7 @@ series.setData(data);`,
     const container = createChartContainer();
     const chart = createChart(container, {
       autoSize: true,
+      symbol: 'AAPL',
       lastPriceLine: { visible: true },
     });
     const series = chart.addCandlestickSeries();
@@ -55,6 +57,7 @@ export const Hidden: Story = {
       source: {
         code: `const chart = createChart(container, {
   autoSize: true,
+  symbol: 'AAPL',
   lastPriceLine: { visible: false },
 });`,
       },
@@ -64,6 +67,7 @@ export const Hidden: Story = {
     const container = createChartContainer();
     const chart = createChart(container, {
       autoSize: true,
+      symbol: 'AAPL',
       lastPriceLine: { visible: false },
     });
     const series = chart.addCandlestickSeries();
@@ -79,6 +83,7 @@ export const OnLineSeries: Story = {
       source: {
         code: `const chart = createChart(container, {
   autoSize: true,
+  symbol: 'AAPL',
   lastPriceLine: { visible: true },
 });
 const series = chart.addLineSeries({ color: '#00e5ff' });
@@ -90,6 +95,7 @@ series.setData(data);`,
     const container = createChartContainer();
     const chart = createChart(container, {
       autoSize: true,
+      symbol: 'AAPL',
       lastPriceLine: { visible: true },
     });
     const series = chart.addLineSeries({ color: '#00e5ff', lineWidth: 2 });

--- a/stories/Features/OHLCLegend.stories.ts
+++ b/stories/Features/OHLCLegend.stories.ts
@@ -29,6 +29,7 @@ export const LegendAndTooltip: Story = {
 
 const chart = createChart(container, {
   autoSize: true,
+  symbol: 'AAPL',
   tooltip: { enabled: true },
 });
 const series = chart.addCandlestickSeries();
@@ -40,6 +41,7 @@ series.setData(data);`,
     const container = createChartContainer();
     const chart = createChart(container, {
       autoSize: true,
+      symbol: 'AAPL',
       tooltip: { enabled: true },
     });
     const series = chart.addCandlestickSeries();
@@ -55,6 +57,7 @@ export const TooltipDisabled: Story = {
       source: {
         code: `const chart = createChart(container, {
   autoSize: true,
+  symbol: 'AAPL',
   tooltip: { enabled: false },
 });`,
       },
@@ -64,6 +67,7 @@ export const TooltipDisabled: Story = {
     const container = createChartContainer();
     const chart = createChart(container, {
       autoSize: true,
+      symbol: 'AAPL',
       tooltip: { enabled: false },
     });
     const series = chart.addCandlestickSeries();
@@ -79,6 +83,7 @@ export const WithVolume: Story = {
       source: {
         code: `const chart = createChart(container, {
   autoSize: true,
+  symbol: 'AAPL',
   tooltip: { enabled: true },
   volume: { visible: true },
 });`,
@@ -89,6 +94,7 @@ export const WithVolume: Story = {
     const container = createChartContainer();
     const chart = createChart(container, {
       autoSize: true,
+      symbol: 'AAPL',
       tooltip: { enabled: true },
       volume: { visible: true },
     });

--- a/stories/Features/Pagination.stories.ts
+++ b/stories/Features/Pagination.stories.ts
@@ -27,7 +27,7 @@ export const InfiniteScrollBack: Story = {
       source: {
         code: `import { createChart } from 'fin-charter';
 
-const chart = createChart(container, { autoSize: true });
+const chart = createChart(container, { autoSize: true, symbol: 'AAPL' });
 const series = chart.addCandlestickSeries();
 series.setData(initialData);
 
@@ -52,7 +52,7 @@ chart.subscribeVisibleRangeChange(async (range) => {
     statusBar.textContent = 'Total bars: 200 — scroll left to load more history';
 
     const container = createChartContainer();
-    const chart = createChart(container, { autoSize: true });
+    const chart = createChart(container, { autoSize: true, symbol: 'AAPL' });
 
     // Seed initial 200 bars ending "today"
     const INITIAL_START = 1704067200; // 2024-01-01

--- a/stories/Features/Periodicity.stories.ts
+++ b/stories/Features/Periodicity.stories.ts
@@ -53,7 +53,7 @@ export const IntervalSwitcher: Story = {
       source: {
         code: `import { createChart } from 'fin-charter';
 
-const chart = createChart(container, { autoSize: true });
+const chart = createChart(container, { autoSize: true, symbol: 'AAPL' });
 const series = chart.addCandlestickSeries();
 series.setData(dailyData);
 
@@ -74,7 +74,7 @@ chart.fitContent();`,
       'background: #1e2235; border-radius: 4px;';
 
     const container = createChartContainer();
-    const chart = createChart(container, { autoSize: true });
+    const chart = createChart(container, { autoSize: true, symbol: 'AAPL' });
     const series = chart.addCandlestickSeries({
       upColor: '#22AB94',
       downColor: '#F7525F',

--- a/stories/Features/PriceLines.stories.ts
+++ b/stories/Features/PriceLines.stories.ts
@@ -26,7 +26,7 @@ export const SupportResistance: Story = {
       source: {
         code: `import { createChart } from 'fin-charter';
 
-const chart = createChart(container, { autoSize: true });
+const chart = createChart(container, { autoSize: true, symbol: 'AAPL' });
 const series = chart.addCandlestickSeries();
 series.setData(data);
 
@@ -41,7 +41,7 @@ series.createPriceLine({
   },
   render: () => {
     const container = createChartContainer();
-    const chart = createChart(container, { autoSize: true });
+    const chart = createChart(container, { autoSize: true, symbol: 'AAPL' });
     const series = chart.addCandlestickSeries();
     series.setData(AAPL_DAILY);
 
@@ -88,7 +88,7 @@ series.createPriceLine({
   },
   render: () => {
     const container = createChartContainer();
-    const chart = createChart(container, { autoSize: true });
+    const chart = createChart(container, { autoSize: true, symbol: 'AAPL' });
     const series = chart.addLineSeries({ color: '#aaaaaa', lineWidth: 1 });
     series.setData(AAPL_DAILY);
 

--- a/stories/Features/Screenshot.stories.ts
+++ b/stories/Features/Screenshot.stories.ts
@@ -26,7 +26,7 @@ export const TakeScreenshot: Story = {
       source: {
         code: `import { createChart } from 'fin-charter';
 
-const chart = createChart(container, { autoSize: true });
+const chart = createChart(container, { autoSize: true, symbol: 'AAPL' });
 const series = chart.addCandlestickSeries();
 series.setData(data);
 
@@ -47,7 +47,7 @@ const dataUrl = canvas.toDataURL('image/png');`,
       'padding: 8px 16px; cursor: pointer; background: #2196f3; color: white; border: none; border-radius: 4px; font-size: 14px; width: fit-content;';
 
     const container = createChartContainer();
-    const chart = createChart(container, { autoSize: true });
+    const chart = createChart(container, { autoSize: true, symbol: 'AAPL' });
 
     const series = chart.addCandlestickSeries();
     series.setData(AAPL_DAILY);

--- a/stories/Features/SeriesMarkers.stories.ts
+++ b/stories/Features/SeriesMarkers.stories.ts
@@ -26,7 +26,7 @@ export const BuySellSignals: Story = {
       source: {
         code: `import { createChart } from 'fin-charter';
 
-const chart = createChart(container, { autoSize: true });
+const chart = createChart(container, { autoSize: true, symbol: 'AAPL' });
 const series = chart.addCandlestickSeries();
 series.setData(data);
 
@@ -39,7 +39,7 @@ series.setMarkers([
   },
   render: () => {
     const container = createChartContainer();
-    const chart = createChart(container, { autoSize: true });
+    const chart = createChart(container, { autoSize: true, symbol: 'AAPL' });
     const series = chart.addCandlestickSeries();
     series.setData(AAPL_DAILY);
 
@@ -86,7 +86,7 @@ export const MultipleMarkers: Story = {
   },
   render: () => {
     const container = createChartContainer();
-    const chart = createChart(container, { autoSize: true });
+    const chart = createChart(container, { autoSize: true, symbol: 'AAPL' });
     const series = chart.addCandlestickSeries();
     series.setData(AAPL_DAILY);
 

--- a/stories/Features/TimeFormatter.stories.ts
+++ b/stories/Features/TimeFormatter.stories.ts
@@ -28,6 +28,7 @@ export const CustomTimeFormatter: Story = {
 
 const chart = createChart(container, {
   autoSize: true,
+  symbol: 'AAPL',
   timeScale: {
     tickMarkFormatter: (time, tickType) => {
       if (tickType === 'day') {
@@ -45,6 +46,7 @@ const chart = createChart(container, {
     const container = createChartContainer();
     const chart = createChart(container, {
       autoSize: true,
+      symbol: 'AAPL',
       timeScale: {
         tickMarkFormatter: (time: number, tickType: 'year' | 'month' | 'day' | 'time') => {
           if (tickType === 'day') {

--- a/stories/Features/VolumeOverlay.stories.ts
+++ b/stories/Features/VolumeOverlay.stories.ts
@@ -28,6 +28,7 @@ export const Default: Story = {
 
 const chart = createChart(container, {
   autoSize: true,
+  symbol: 'AAPL',
   volume: { visible: true },
 });
 const series = chart.addCandlestickSeries();
@@ -39,6 +40,7 @@ series.setData(data);`,
     const container = createChartContainer();
     const chart = createChart(container, {
       autoSize: true,
+      symbol: 'AAPL',
       volume: { visible: true },
     });
     const series = chart.addCandlestickSeries();
@@ -54,6 +56,7 @@ export const CustomVolumeColors: Story = {
       source: {
         code: `const chart = createChart(container, {
   autoSize: true,
+  symbol: 'AAPL',
   volume: {
     visible: true,
     upColor: 'rgba(0, 229, 255, 0.5)',
@@ -67,6 +70,7 @@ export const CustomVolumeColors: Story = {
     const container = createChartContainer();
     const chart = createChart(container, {
       autoSize: true,
+      symbol: 'AAPL',
       volume: {
         visible: true,
         upColor: 'rgba(0, 229, 255, 0.5)',

--- a/stories/Features/Watermark.stories.ts
+++ b/stories/Features/Watermark.stories.ts
@@ -28,6 +28,7 @@ export const Default: Story = {
 
 const chart = createChart(container, {
   autoSize: true,
+  symbol: 'AAPL',
   watermark: {
     visible: true,
     text: 'AAPL',
@@ -42,6 +43,7 @@ const chart = createChart(container, {
     const container = createChartContainer();
     const chart = createChart(container, {
       autoSize: true,
+      symbol: 'AAPL',
       watermark: {
         visible: true,
         text: 'AAPL',
@@ -64,6 +66,7 @@ export const LargeText: Story = {
       source: {
         code: `const chart = createChart(container, {
   autoSize: true,
+  symbol: 'AAPL',
   watermark: {
     visible: true,
     text: 'FIN-CHARTER',
@@ -78,6 +81,7 @@ export const LargeText: Story = {
     const container = createChartContainer();
     const chart = createChart(container, {
       autoSize: true,
+      symbol: 'AAPL',
       watermark: {
         visible: true,
         text: 'FIN-CHARTER',
@@ -104,6 +108,7 @@ export const CornerWatermark: Story = {
       source: {
         code: `const chart = createChart(container, {
   autoSize: true,
+  symbol: 'AAPL',
   watermark: {
     visible: true, text: 'DEMO', fontSize: 32,
     horzAlign: 'right', vertAlign: 'bottom',
@@ -116,6 +121,7 @@ export const CornerWatermark: Story = {
     const container = createChartContainer();
     const chart = createChart(container, {
       autoSize: true,
+      symbol: 'AAPL',
       watermark: {
         visible: true,
         text: 'DEMO',

--- a/stories/HollowCandleChart.stories.ts
+++ b/stories/HollowCandleChart.stories.ts
@@ -26,7 +26,7 @@ export const Default: Story = {
         code: `
 import { createChart } from 'fin-charter';
 
-const chart = createChart(document.getElementById('chart'), { autoSize: true });
+const chart = createChart(document.getElementById('chart'), { autoSize: true, symbol: 'AAPL' });
 const series = chart.addHollowCandleSeries();
 series.setData(data);
 `.trim(),
@@ -35,7 +35,7 @@ series.setData(data);
   },
   render: () => {
     const container = createChartContainer();
-    const chart = createChart(container, { autoSize: true });
+    const chart = createChart(container, { autoSize: true, symbol: 'AAPL' });
     const series = chart.addHollowCandleSeries();
     series.setData(AAPL_DAILY);
     return container;
@@ -60,7 +60,7 @@ series.setData(data);
   },
   render: () => {
     const container = createChartContainer();
-    const chart = createChart(container, { autoSize: true });
+    const chart = createChart(container, { autoSize: true, symbol: 'AAPL' });
     const series = chart.addHollowCandleSeries({
       upColor: '#00e5ff',
       downColor: '#ff4081',

--- a/stories/Indicators-Extended.stories.ts
+++ b/stories/Indicators-Extended.stories.ts
@@ -51,7 +51,7 @@ export const VWAPOverlay: Story = {
         code: `import { createChart } from 'fin-charter';
 import { computeVWAP } from 'fin-charter/indicators';
 
-const chart = createChart(container, { autoSize: true });
+const chart = createChart(container, { autoSize: true, symbol: 'AAPL' });
 const series = chart.addCandlestickSeries();
 series.setData(bars);
 
@@ -62,7 +62,7 @@ chart.addLineSeries({ color: '#ff9800', lineWidth: 2 }).setData(vwapBars);`,
   },
   render: () => {
     const container = createChartContainer();
-    const chart = createChart(container, { autoSize: true });
+    const chart = createChart(container, { autoSize: true, symbol: 'AAPL' });
 
     const candleSeries = chart.addCandlestickSeries();
     candleSeries.setData(AAPL_DAILY);
@@ -99,7 +99,7 @@ export const StochasticOscillator: Story = {
   render: () => {
     const container = createChartContainer();
     container.style.height = '600px';
-    const chart = createChart(container, { autoSize: true });
+    const chart = createChart(container, { autoSize: true, symbol: 'AAPL' });
 
     const candleSeries = chart.addCandlestickSeries();
     candleSeries.setData(AAPL_DAILY);
@@ -134,7 +134,7 @@ export const ATRIndicator: Story = {
   render: () => {
     const container = createChartContainer();
     container.style.height = '600px';
-    const chart = createChart(container, { autoSize: true });
+    const chart = createChart(container, { autoSize: true, symbol: 'AAPL' });
 
     const candleSeries = chart.addCandlestickSeries();
     candleSeries.setData(AAPL_DAILY);
@@ -169,7 +169,7 @@ export const ADXIndicator: Story = {
   render: () => {
     const container = createChartContainer();
     container.style.height = '600px';
-    const chart = createChart(container, { autoSize: true });
+    const chart = createChart(container, { autoSize: true, symbol: 'AAPL' });
 
     const candleSeries = chart.addCandlestickSeries();
     candleSeries.setData(AAPL_DAILY);
@@ -203,7 +203,7 @@ export const OBVIndicator: Story = {
   render: () => {
     const container = createChartContainer();
     container.style.height = '600px';
-    const chart = createChart(container, { autoSize: true });
+    const chart = createChart(container, { autoSize: true, symbol: 'AAPL' });
 
     const candleSeries = chart.addCandlestickSeries();
     candleSeries.setData(AAPL_DAILY);
@@ -237,7 +237,7 @@ export const WilliamsRIndicator: Story = {
   render: () => {
     const container = createChartContainer();
     container.style.height = '600px';
-    const chart = createChart(container, { autoSize: true });
+    const chart = createChart(container, { autoSize: true, symbol: 'AAPL' });
 
     const candleSeries = chart.addCandlestickSeries();
     candleSeries.setData(AAPL_DAILY);

--- a/stories/Indicators-Production.stories.ts
+++ b/stories/Indicators-Production.stories.ts
@@ -28,7 +28,7 @@ export const IchimokuCloud: Story = {
       source: {
         code: `import { createChart } from 'fin-charter';
 
-const chart = createChart(container, { autoSize: true });
+const chart = createChart(container, { autoSize: true, symbol: 'AAPL' });
 const series = chart.addCandlestickSeries();
 series.setData(bars);
 
@@ -43,7 +43,7 @@ chart.addIndicator('ichimoku', {
   render: () => {
     const container = createChartContainer();
     container.style.height = '600px';
-    const chart = createChart(container, { autoSize: true });
+    const chart = createChart(container, { autoSize: true, symbol: 'AAPL' });
 
     const series = chart.addCandlestickSeries();
     series.setData(AAPL_DAILY);
@@ -77,7 +77,7 @@ export const ParabolicSAR: Story = {
   render: () => {
     const container = createChartContainer();
     container.style.height = '600px';
-    const chart = createChart(container, { autoSize: true });
+    const chart = createChart(container, { autoSize: true, symbol: 'AAPL' });
 
     const series = chart.addCandlestickSeries();
     series.setData(AAPL_DAILY);
@@ -112,7 +112,7 @@ export const KeltnerChannel: Story = {
   render: () => {
     const container = createChartContainer();
     container.style.height = '600px';
-    const chart = createChart(container, { autoSize: true });
+    const chart = createChart(container, { autoSize: true, symbol: 'AAPL' });
 
     const series = chart.addCandlestickSeries();
     series.setData(AAPL_DAILY);
@@ -147,7 +147,7 @@ export const DonchianChannel: Story = {
   render: () => {
     const container = createChartContainer();
     container.style.height = '600px';
-    const chart = createChart(container, { autoSize: true });
+    const chart = createChart(container, { autoSize: true, symbol: 'AAPL' });
 
     const series = chart.addCandlestickSeries();
     series.setData(AAPL_DAILY);
@@ -182,7 +182,7 @@ export const CCIIndicator: Story = {
   render: () => {
     const container = createChartContainer();
     container.style.height = '600px';
-    const chart = createChart(container, { autoSize: true });
+    const chart = createChart(container, { autoSize: true, symbol: 'AAPL' });
 
     const series = chart.addCandlestickSeries();
     series.setData(AAPL_DAILY);
@@ -216,7 +216,7 @@ export const PivotPoints: Story = {
   render: () => {
     const container = createChartContainer();
     container.style.height = '600px';
-    const chart = createChart(container, { autoSize: true });
+    const chart = createChart(container, { autoSize: true, symbol: 'AAPL' });
 
     const series = chart.addCandlestickSeries();
     series.setData(AAPL_DAILY);

--- a/stories/Indicators.stories.ts
+++ b/stories/Indicators.stories.ts
@@ -41,7 +41,7 @@ export const SMAandEMA: Story = {
         code: `import { createChart } from 'fin-charter';
 import { computeSMA, computeEMA } from 'fin-charter/indicators';
 
-const chart = createChart(container, { autoSize: true });
+const chart = createChart(container, { autoSize: true, symbol: 'AAPL' });
 const series = chart.addCandlestickSeries();
 series.setData(bars);
 
@@ -56,7 +56,7 @@ chart.addLineSeries({ color: '#00e5ff', lineWidth: 2 }).setData(emaLineBars);`,
   },
   render: () => {
     const container = createChartContainer();
-    const chart = createChart(container, { autoSize: true });
+    const chart = createChart(container, { autoSize: true, symbol: 'AAPL' });
 
     const bars = AAPL_DAILY;
     const closes = new Float64Array(bars.map((b) => b.close));
@@ -93,7 +93,7 @@ smaSeries.setData(smaLineBars);`,
   },
   render: () => {
     const container = createChartContainer();
-    const chart = createChart(container, { autoSize: true });
+    const chart = createChart(container, { autoSize: true, symbol: 'AAPL' });
 
     const bars = AAPL_DAILY;
     const closes = new Float64Array(bars.map((b) => b.close));
@@ -125,7 +125,7 @@ chart.addLineSeries({ color: '#00e5ff', lineWidth: 2 }).setData(ema26Bars);`,
   },
   render: () => {
     const container = createChartContainer();
-    const chart = createChart(container, { autoSize: true });
+    const chart = createChart(container, { autoSize: true, symbol: 'AAPL' });
 
     const bars = AAPL_DAILY;
     const closes = new Float64Array(bars.map((b) => b.close));

--- a/stories/LineChart.stories.ts
+++ b/stories/LineChart.stories.ts
@@ -25,7 +25,7 @@ export const Default: Story = {
         code: `
 import { createChart } from 'fin-charter';
 
-const chart = createChart(document.getElementById('chart'), { autoSize: true });
+const chart = createChart(document.getElementById('chart'), { autoSize: true, symbol: 'AAPL' });
 const series = chart.addLineSeries();
 series.setData(data);
 `.trim(),
@@ -34,7 +34,7 @@ series.setData(data);
   },
   render: () => {
     const container = createChartContainer();
-    const chart = createChart(container, { autoSize: true });
+    const chart = createChart(container, { autoSize: true, symbol: 'AAPL' });
     const series = chart.addLineSeries();
     series.setData(AAPL_DAILY);
     return container;
@@ -58,7 +58,7 @@ series.setData(data);
   },
   render: () => {
     const container = createChartContainer();
-    const chart = createChart(container, { autoSize: true });
+    const chart = createChart(container, { autoSize: true, symbol: 'AAPL' });
     const series = chart.addLineSeries({
       color: '#00e5ff',
       lineWidth: 2,
@@ -82,7 +82,7 @@ series.setData(data);
   },
   render: () => {
     const container = createChartContainer();
-    const chart = createChart(container, { autoSize: true });
+    const chart = createChart(container, { autoSize: true, symbol: 'AAPL' });
     const series = chart.addLineSeries({ color: '#ff6b6b' });
     series.setData(AAPL_DAILY);
     return container;

--- a/stories/MultiSeries.stories.ts
+++ b/stories/MultiSeries.stories.ts
@@ -25,7 +25,7 @@ export const TwoLineSeriesOverlaid: Story = {
         code: `
 import { createChart } from 'fin-charter';
 
-const chart = createChart(document.getElementById('chart'), { autoSize: true });
+const chart = createChart(document.getElementById('chart'), { autoSize: true, symbol: 'AAPL' });
 
 const series1 = chart.addLineSeries({ color: '#2962FF', lineWidth: 2 });
 series1.setData(stockA);
@@ -38,7 +38,7 @@ series2.setData(stockB);
   },
   render: () => {
     const container = createChartContainer();
-    const chart = createChart(container, { autoSize: true });
+    const chart = createChart(container, { autoSize: true, symbol: 'AAPL' });
 
     const series1 = chart.addLineSeries({ color: '#2962FF', lineWidth: 2 });
     series1.setData(AAPL_DAILY);
@@ -75,7 +75,7 @@ sma.setData(smaData);
   },
   render: () => {
     const container = createChartContainer();
-    const chart = createChart(container, { autoSize: true });
+    const chart = createChart(container, { autoSize: true, symbol: 'AAPL' });
 
     const candleSeries = chart.addCandlestickSeries();
     candleSeries.setData(AAPL_DAILY);
@@ -102,6 +102,7 @@ export const WithVolumeOverlay: Story = {
         code: `
 const chart = createChart(container, {
   autoSize: true,
+  symbol: 'AAPL',
   volume: { visible: true },
 });
 chart.addCandlestickSeries().setData(data);
@@ -113,6 +114,7 @@ chart.addCandlestickSeries().setData(data);
     const container = createChartContainer();
     const chart = createChart(container, {
       autoSize: true,
+      symbol: 'AAPL',
       volume: { visible: true },
     });
 
@@ -146,7 +148,7 @@ series.createPriceLine({
   },
   render: () => {
     const container = createChartContainer();
-    const chart = createChart(container, { autoSize: true });
+    const chart = createChart(container, { autoSize: true, symbol: 'AAPL' });
 
     const series = chart.addCandlestickSeries();
     series.setData(AAPL_DAILY);
@@ -179,6 +181,7 @@ export const WithWatermark: Story = {
         code: `
 const chart = createChart(container, {
   autoSize: true,
+  symbol: 'AAPL',
   watermark: {
     visible: true,
     text: 'AAPL',
@@ -195,6 +198,7 @@ chart.addCandlestickSeries().setData(data);
     const container = createChartContainer();
     const chart = createChart(container, {
       autoSize: true,
+      symbol: 'AAPL',
       watermark: {
         visible: true,
         text: 'AAPL',

--- a/stories/Navigation/GoToRealtime.stories.ts
+++ b/stories/Navigation/GoToRealtime.stories.ts
@@ -26,7 +26,7 @@ export const Default: Story = {
       source: {
         code: `import { createChart } from 'fin-charter';
 
-const chart = createChart(container, { autoSize: true });
+const chart = createChart(container, { autoSize: true, symbol: 'AAPL' });
 const series = chart.addCandlestickSeries();
 series.setData(bars);
 
@@ -45,7 +45,7 @@ chart.scrollToRealTime();`,
     toolbar.style.cssText = 'display:flex;gap:6px;padding:4px 8px;background:#1a1a2e;border-radius:4px;';
 
     const container = createChartContainer();
-    const chart = createChart(container, { autoSize: true });
+    const chart = createChart(container, { autoSize: true, symbol: 'AAPL' });
     const series = chart.addCandlestickSeries();
 
     const seedData = generateOHLCV(100);

--- a/stories/Navigation/InfiniteHistory.stories.ts
+++ b/stories/Navigation/InfiniteHistory.stories.ts
@@ -47,7 +47,7 @@ export const Default: Story = {
       source: {
         code: `import { createChart } from 'fin-charter';
 
-const chart = createChart(container, { autoSize: true });
+const chart = createChart(container, { autoSize: true, symbol: 'AAPL' });
 const series = chart.addCandlestickSeries();
 series.setData(bars);
 
@@ -74,7 +74,7 @@ chart.subscribeVisibleRangeChange(async (range) => {
     loadingEl.textContent = 'Loading historical data...';
 
     const container = createChartContainer();
-    const chart = createChart(container, { autoSize: true });
+    const chart = createChart(container, { autoSize: true, symbol: 'AAPL' });
     const series = chart.addCandlestickSeries();
 
     let allBars: Bar[] = [...AAPL_DAILY];

--- a/stories/Navigation/RangeSwitcher.stories.ts
+++ b/stories/Navigation/RangeSwitcher.stories.ts
@@ -27,7 +27,7 @@ export const Default: Story = {
       source: {
         code: `import { createChart } from 'fin-charter';
 
-const chart = createChart(container, { autoSize: true });
+const chart = createChart(container, { autoSize: true, symbol: 'AAPL' });
 const series = chart.addCandlestickSeries();
 series.setData(bars);
 
@@ -53,7 +53,7 @@ chart.scrollToRealTime();`,
 
     const container = createChartContainer();
 
-    const chart = createChart(container, { autoSize: true });
+    const chart = createChart(container, { autoSize: true, symbol: 'AAPL' });
     const series = chart.addCandlestickSeries();
     series.setData(AAPL_DAILY);
 

--- a/stories/RealTimeChart.stories.ts
+++ b/stories/RealTimeChart.stories.ts
@@ -25,7 +25,7 @@ export const LiveStream: Story = {
       source: {
         code: `import { createChart } from 'fin-charter';
 
-const chart = createChart(container, { autoSize: true });
+const chart = createChart(container, { autoSize: true, symbol: 'AAPL' });
 const series = chart.addCandlestickSeries();
 series.setData(historicalBars);
 
@@ -39,7 +39,7 @@ setInterval(() => {
   },
   render: () => {
     const container = createChartContainer();
-    const chart = createChart(container, { autoSize: true });
+    const chart = createChart(container, { autoSize: true, symbol: 'AAPL' });
     const series = chart.addCandlestickSeries();
 
     // Seed with 100 historical bars
@@ -97,7 +97,7 @@ setInterval(() => {
   },
   render: () => {
     const container = createChartContainer();
-    const chart = createChart(container, { autoSize: true });
+    const chart = createChart(container, { autoSize: true, symbol: 'AAPL' });
     const series = chart.addLineSeries({ color: '#00e5ff', lineWidth: 2 });
 
     const seedData = generateOHLCV(100);


### PR DESCRIPTION
…'AAPL' instead of generic 'Symbol'

The recent chart-level symbol fix (a99518e) added fallback to `this._options.symbol` for the HUD label, but none of the Storybook stories passed a `symbol` option to `createChart()`, causing every story to still display "Symbol" in the legend.