### PR TITLE
feat: infinite history, per-indicator settings & material design icons

### DIFF
--- a/dev/components/Icon.svelte
+++ b/dev/components/Icon.svelte
@@ -1,0 +1,19 @@
+<script lang="ts">
+  interface Props {
+    path: string;
+    size?: number;
+    color?: string;
+  }
+
+  let { path, size = 18, color = 'currentColor' }: Props = $props();
+</script>
+
+<svg
+  viewBox="0 0 24 24"
+  width={size}
+  height={size}
+  fill={color}
+  style="display:inline-block;vertical-align:middle;"
+>
+  <path d={path} />
+</svg>

--- a/dev/components/Sidebar/Sidebar.svelte
+++ b/dev/components/Sidebar/Sidebar.svelte
@@ -1,13 +1,17 @@
 <script lang="ts">
   import { appStore } from '../../data/store.svelte.ts';
   import Watchlist from './Watchlist.svelte';
+  import Icon from '../Icon.svelte';
+  import { mdiFormatListBulleted, mdiChevronLeft } from '@mdi/js';
 </script>
 
 {#if appStore.sidebarOpen}
   <div class="sidebar">
     <div class="sidebar-header">
-      <span class="title">Watchlist</span>
-      <button class="collapse-btn" onclick={() => { appStore.sidebarOpen = false; }}>◀</button>
+      <span class="title"><Icon path={mdiFormatListBulleted} size={14} /> Watchlist</span>
+      <button class="collapse-btn" onclick={() => { appStore.sidebarOpen = false; }}>
+        <Icon path={mdiChevronLeft} size={16} />
+      </button>
     </div>
     <Watchlist />
   </div>
@@ -34,6 +38,9 @@
   }
 
   .title {
+    display: flex;
+    align-items: center;
+    gap: 4px;
     font-size: 12px;
     font-weight: 600;
     color: #d1d4dc;

--- a/dev/components/StatusBar/StatusBar.svelte
+++ b/dev/components/StatusBar/StatusBar.svelte
@@ -3,6 +3,8 @@
   import { getMarketForExchange } from 'fin-charter/market';
   import { getSymbolInfo } from '../../data/symbols';
   import { VERSION } from 'fin-charter';
+  import Icon from '../Icon.svelte';
+  import { mdiChevronRight } from '@mdi/js';
 
   let info = $derived(getSymbolInfo(appStore.symbol));
   let market = $derived(info ? getMarketForExchange(info.exchange) : undefined);
@@ -20,7 +22,7 @@
   <span class="spacer"></span>
   {#if !appStore.sidebarOpen}
     <button class="sidebar-toggle" onclick={() => { appStore.sidebarOpen = true; }}>
-      Watchlist ▶
+      Watchlist <Icon path={mdiChevronRight} size={12} />
     </button>
   {/if}
   <span class="version">fin-charter v{VERSION}</span>
@@ -66,6 +68,9 @@
   }
 
   .sidebar-toggle {
+    display: flex;
+    align-items: center;
+    gap: 2px;
     background: transparent;
     border: none;
     color: #758696;

--- a/dev/components/Toolbar/ChartTypeSelector.svelte
+++ b/dev/components/Toolbar/ChartTypeSelector.svelte
@@ -1,22 +1,32 @@
 <script lang="ts">
   import { appStore } from '../../data/store.svelte.ts';
   import type { ChartTypeLabel } from '../../data/store.svelte.ts';
+  import Icon from '../Icon.svelte';
+  import {
+    mdiFinance,
+    mdiChartLine,
+    mdiChartAreaspline,
+    mdiChartBar,
+    mdiChartBellCurve,
+    mdiChartTimelineVariant,
+    mdiCandle,
+  } from '@mdi/js';
 
   let open = $state(false);
   let containerEl: HTMLDivElement | undefined;
 
   const CHART_TYPES: { label: ChartTypeLabel; icon: string }[] = [
-    { label: 'Candlestick', icon: '🕯' },
-    { label: 'Line', icon: '📈' },
-    { label: 'Area', icon: '▤' },
-    { label: 'Bar', icon: '┃' },
-    { label: 'Baseline', icon: '⎯' },
-    { label: 'HollowCandle', icon: '◇' },
-    { label: 'HeikinAshi', icon: '⊞' },
+    { label: 'Candlestick', icon: mdiFinance },
+    { label: 'Line', icon: mdiChartLine },
+    { label: 'Area', icon: mdiChartAreaspline },
+    { label: 'Bar', icon: mdiChartBar },
+    { label: 'Baseline', icon: mdiChartBellCurve },
+    { label: 'HollowCandle', icon: mdiCandle },
+    { label: 'HeikinAshi', icon: mdiChartTimelineVariant },
   ];
 
   let currentIcon = $derived(
-    CHART_TYPES.find(t => t.label === appStore.chartType)?.icon ?? '🕯'
+    CHART_TYPES.find(t => t.label === appStore.chartType)?.icon ?? mdiFinance
   );
 
   function select(type: ChartTypeLabel) {
@@ -42,7 +52,7 @@
 
 <div class="chart-type-selector" bind:this={containerEl}>
   <button class="trigger" aria-label="Chart type" onclick={() => (open = !open)}>
-    {currentIcon}
+    <Icon path={currentIcon} size={18} />
   </button>
 
   {#if open}
@@ -53,7 +63,7 @@
           class:active={appStore.chartType === ct.label}
           onclick={() => select(ct.label)}
         >
-          <span class="icon">{ct.icon}</span>
+          <span class="icon"><Icon path={ct.icon} size={18} /></span>
           <span class="label">{ct.label}</span>
         </button>
       {/each}
@@ -75,6 +85,8 @@
     cursor: pointer;
     font-size: 14px;
     font-family: inherit;
+    display: flex;
+    align-items: center;
   }
 
   .trigger:hover {
@@ -91,7 +103,7 @@
     border: 1px solid #1a2332;
     border-radius: 6px;
     box-shadow: 0 8px 24px rgba(0, 0, 0, 0.5);
-    min-width: 160px;
+    min-width: 170px;
     padding: 4px 0;
   }
 
@@ -120,7 +132,8 @@
 
   .icon {
     width: 20px;
-    text-align: center;
-    font-size: 14px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
   }
 </style>

--- a/dev/components/Toolbar/CompareButton.svelte
+++ b/dev/components/Toolbar/CompareButton.svelte
@@ -1,6 +1,8 @@
 <script lang="ts">
   import { searchSymbols } from '../../data/symbols';
   import { appStore } from '../../data/store.svelte.ts';
+  import Icon from '../Icon.svelte';
+  import { mdiChartMultiple, mdiClose } from '@mdi/js';
 
   let open = $state(false);
   let query = $state('');
@@ -49,6 +51,7 @@
 
 <div class="compare-button" bind:this={containerEl}>
   <button class="trigger" class:active={appStore.comparisonMode} onclick={toggle}>
+    <Icon path={mdiChartMultiple} size={16} />
     Compare
   </button>
 
@@ -69,7 +72,9 @@
           {#each appStore.comparisonSymbols as sym}
             <div class="active-item">
               <span class="sym">{sym}</span>
-              <button class="remove" onclick={() => removeComparison(sym)}>&#10005;</button>
+              <button class="remove" onclick={() => removeComparison(sym)}>
+                <Icon path={mdiClose} size={14} />
+              </button>
             </div>
           {/each}
         </div>
@@ -98,6 +103,9 @@
   }
 
   .trigger {
+    display: flex;
+    align-items: center;
+    gap: 4px;
     background: transparent;
     border: 1px solid transparent;
     color: #758696;
@@ -177,10 +185,11 @@
     border: none;
     color: #758696;
     cursor: pointer;
-    font-size: 12px;
     padding: 2px 4px;
     border-radius: 2px;
     font-family: inherit;
+    display: flex;
+    align-items: center;
   }
 
   .remove:hover {

--- a/dev/components/Toolbar/DrawingToolbar.svelte
+++ b/dev/components/Toolbar/DrawingToolbar.svelte
@@ -1,46 +1,67 @@
 <script lang="ts">
   import { appStore } from '../../data/store.svelte.ts';
+  import Icon from '../Icon.svelte';
+  import {
+    mdiPencilRuler,
+    mdiMinus,
+    mdiArrowTopRight,
+    mdiVectorLine,
+    mdiRayStartArrow,
+    mdiArrowRight,
+    mdiCrosshairsGps,
+    mdiWaves,
+    mdiChartSankey,
+    mdiCircleOutline,
+    mdiSetCenter,
+    mdiRectangleOutline,
+    mdiEllipseOutline,
+    mdiViewParallel,
+    mdiPitchfork,
+    mdiTextBox,
+    mdiRuler,
+    mdiClose,
+  } from '@mdi/js';
 
   interface DrawingGroup {
     label: string;
-    tools: { id: string; name: string }[];
+    tools: { id: string; name: string; icon: string }[];
   }
 
   const DRAWING_GROUPS: DrawingGroup[] = [
     {
       label: 'Lines',
       tools: [
-        { id: 'horizontal-line', name: 'Horizontal Line' },
-        { id: 'vertical-line', name: 'Vertical Line' },
-        { id: 'trendline', name: 'Trendline' },
-        { id: 'ray', name: 'Ray' },
-        { id: 'arrow', name: 'Arrow' },
-        { id: 'crossline', name: 'Crossline' },
+        { id: 'horizontal-line', name: 'Horizontal Line', icon: mdiMinus },
+        { id: 'vertical-line', name: 'Vertical Line', icon: mdiArrowTopRight },
+        { id: 'trendline', name: 'Trendline', icon: mdiVectorLine },
+        { id: 'ray', name: 'Ray', icon: mdiRayStartArrow },
+        { id: 'arrow', name: 'Arrow', icon: mdiArrowRight },
+        { id: 'crossline', name: 'Crossline', icon: mdiCrosshairsGps },
       ],
     },
     {
       label: 'Fibonacci',
       tools: [
-        { id: 'fibonacci', name: 'Fibonacci Retracement' },
-        { id: 'fib-projection', name: 'Fib Projection' },
-        { id: 'fib-arc', name: 'Fib Arc' },
-        { id: 'fib-fan', name: 'Fib Fan' },
+        { id: 'fibonacci', name: 'Fibonacci Retracement', icon: mdiWaves },
+        { id: 'fib-projection', name: 'Fib Projection', icon: mdiChartSankey },
+        { id: 'fib-arc', name: 'Fib Arc', icon: mdiCircleOutline },
+        { id: 'fib-fan', name: 'Fib Fan', icon: mdiSetCenter },
       ],
     },
     {
       label: 'Shapes',
       tools: [
-        { id: 'rectangle', name: 'Rectangle' },
-        { id: 'ellipse', name: 'Ellipse' },
-        { id: 'channel', name: 'Channel' },
-        { id: 'pitchfork', name: 'Pitchfork' },
+        { id: 'rectangle', name: 'Rectangle', icon: mdiRectangleOutline },
+        { id: 'ellipse', name: 'Ellipse', icon: mdiEllipseOutline },
+        { id: 'channel', name: 'Channel', icon: mdiViewParallel },
+        { id: 'pitchfork', name: 'Pitchfork', icon: mdiPitchfork },
       ],
     },
     {
       label: 'Annotations',
       tools: [
-        { id: 'text-annotation', name: 'Text Annotation' },
-        { id: 'measurement', name: 'Measurement' },
+        { id: 'text-annotation', name: 'Text Annotation', icon: mdiTextBox },
+        { id: 'measurement', name: 'Measurement', icon: mdiRuler },
       ],
     },
   ];
@@ -82,12 +103,14 @@
 
 <div class="drawing-toolbar" bind:this={containerEl}>
   <button class="trigger" class:active={hasActiveTool} onclick={() => (open = !open)}>
+    <Icon path={mdiPencilRuler} size={16} />
     Draw
   </button>
 
   {#if open}
     <div class="dropdown">
       <button class="item none" class:active={!hasActiveTool} onclick={clearTool}>
+        <span class="tool-icon"><Icon path={mdiClose} size={16} /></span>
         None
       </button>
 
@@ -99,6 +122,7 @@
             class:active={appStore.activeDrawingTool === tool.id}
             onclick={() => selectTool(tool.id)}
           >
+            <span class="tool-icon"><Icon path={tool.icon} size={16} /></span>
             {tool.name}
           </button>
         {/each}
@@ -113,6 +137,9 @@
   }
 
   .trigger {
+    display: flex;
+    align-items: center;
+    gap: 4px;
     background: transparent;
     border: 1px solid transparent;
     color: #758696;
@@ -141,7 +168,7 @@
     border: 1px solid #1a2332;
     border-radius: 6px;
     box-shadow: 0 8px 24px rgba(0, 0, 0, 0.5);
-    width: 200px;
+    width: 220px;
     max-height: 400px;
     overflow-y: auto;
     padding: 4px 0;
@@ -157,7 +184,9 @@
   }
 
   .item {
-    display: block;
+    display: flex;
+    align-items: center;
+    gap: 8px;
     width: 100%;
     padding: 6px 12px;
     background: transparent;
@@ -180,5 +209,13 @@
   .item.none {
     border-bottom: 1px solid #1a2332;
     margin-bottom: 2px;
+  }
+
+  .tool-icon {
+    width: 18px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    flex-shrink: 0;
   }
 </style>

--- a/dev/components/Toolbar/IndicatorDialog.svelte
+++ b/dev/components/Toolbar/IndicatorDialog.svelte
@@ -1,5 +1,8 @@
 <script lang="ts">
   import { appStore } from '../../data/store.svelte.ts';
+  import Icon from '../Icon.svelte';
+  import { mdiChartBellCurveCumulative, mdiCog, mdiCheck } from '@mdi/js';
+  import IndicatorSettingsPanel from './IndicatorSettingsPanel.svelte';
 
   const INDICATOR_LIST = [
     { id: 'sma', name: 'SMA', category: 'Overlay' },
@@ -35,6 +38,7 @@
 
   let open = $state(false);
   let query = $state('');
+  let settingsFor = $state<string | null>(null);
   let containerEl: HTMLDivElement | undefined;
   let inputEl: HTMLInputElement | undefined = $state(undefined);
 
@@ -51,21 +55,31 @@
   function toggleIndicator(id: string) {
     if (appStore.activeIndicators.includes(id)) {
       appStore.removeIndicator(id);
+      if (settingsFor === id) settingsFor = null;
     } else {
       appStore.addIndicator(id);
     }
   }
 
+  function openSettings(e: MouseEvent, id: string) {
+    e.stopPropagation();
+    settingsFor = settingsFor === id ? null : id;
+  }
+
   function toggle() {
     open = !open;
     if (open) setTimeout(() => inputEl?.focus(), 0);
-    if (!open) query = '';
+    if (!open) {
+      query = '';
+      settingsFor = null;
+    }
   }
 
   function handleClickOutside(e: MouseEvent) {
     if (containerEl && !containerEl.contains(e.target as Node)) {
       open = false;
       query = '';
+      settingsFor = null;
     }
   }
 
@@ -81,6 +95,7 @@
 
 <div class="indicator-dialog" bind:this={containerEl}>
   <button class="trigger" onclick={toggle}>
+    <Icon path={mdiChartBellCurveCumulative} size={16} />
     Indicators
     {#if indicatorCount > 0}
       <span class="badge">{indicatorCount}</span>
@@ -100,23 +115,41 @@
       </div>
       <div class="list">
         {#each filtered() as ind}
-          <button
-            class="item"
-            class:active={appStore.activeIndicators.includes(ind.id)}
-            onclick={() => toggleIndicator(ind.id)}
-          >
-            <span class="name">{ind.name}</span>
-            <span class="category">{ind.category}</span>
+          <div class="item-row" class:active={appStore.activeIndicators.includes(ind.id)}>
+            <button
+              class="item"
+              class:active={appStore.activeIndicators.includes(ind.id)}
+              onclick={() => toggleIndicator(ind.id)}
+            >
+              <span class="name">{ind.name}</span>
+              <span class="category">{ind.category}</span>
+              {#if appStore.activeIndicators.includes(ind.id)}
+                <span class="check"><Icon path={mdiCheck} size={14} /></span>
+              {/if}
+            </button>
             {#if appStore.activeIndicators.includes(ind.id)}
-              <span class="check">&#10003;</span>
+              <button
+                class="gear-btn"
+                title="Settings"
+                onclick={(e: MouseEvent) => openSettings(e, ind.id)}
+              >
+                <Icon path={mdiCog} size={14} />
+              </button>
             {/if}
-          </button>
+          </div>
         {/each}
         {#if filtered().length === 0}
           <div class="no-results">No indicators found</div>
         {/if}
       </div>
     </div>
+  {/if}
+
+  {#if settingsFor}
+    <IndicatorSettingsPanel
+      indicatorId={settingsFor}
+      onclose={() => { settingsFor = null; }}
+    />
   {/if}
 </div>
 
@@ -166,7 +199,7 @@
     border: 1px solid #1a2332;
     border-radius: 6px;
     box-shadow: 0 8px 24px rgba(0, 0, 0, 0.5);
-    width: 280px;
+    width: 300px;
     max-height: 400px;
     display: flex;
     flex-direction: column;
@@ -200,11 +233,16 @@
     padding: 4px 0;
   }
 
+  .item-row {
+    display: flex;
+    align-items: center;
+  }
+
   .item {
     display: flex;
     align-items: center;
     gap: 8px;
-    width: 100%;
+    flex: 1;
     padding: 8px 12px;
     background: transparent;
     border: none;
@@ -234,7 +272,24 @@
 
   .check {
     color: #2962ff;
-    font-size: 14px;
+    display: flex;
+    align-items: center;
+  }
+
+  .gear-btn {
+    background: transparent;
+    border: none;
+    color: #758696;
+    cursor: pointer;
+    padding: 6px 8px;
+    display: flex;
+    align-items: center;
+    border-radius: 3px;
+  }
+
+  .gear-btn:hover {
+    color: #d1d4dc;
+    background: rgba(255, 255, 255, 0.06);
   }
 
   .no-results {

--- a/dev/components/Toolbar/IndicatorSettingsPanel.svelte
+++ b/dev/components/Toolbar/IndicatorSettingsPanel.svelte
@@ -1,0 +1,288 @@
+<script lang="ts">
+  import { appStore } from '../../data/store.svelte.ts';
+  import { INDICATOR_SETTINGS, type IndicatorSettingsDef } from '../../data/indicator-settings';
+  import Icon from '../Icon.svelte';
+  import { mdiClose } from '@mdi/js';
+
+  interface Props {
+    indicatorId: string;
+    onclose: () => void;
+  }
+
+  let { indicatorId, onclose }: Props = $props();
+
+  let def: IndicatorSettingsDef | undefined = $derived(INDICATOR_SETTINGS[indicatorId]);
+
+  // Local editable copies of params and styles
+  let localParams = $state<Record<string, number>>({});
+  let localStyles = $state<Record<string, string | number>>({});
+
+  // Init from store or defaults
+  $effect(() => {
+    if (!def) return;
+    const saved = appStore.indicatorSettings[indicatorId];
+    const p: Record<string, number> = {};
+    for (const pd of def.params) {
+      p[pd.key] = saved?.params[pd.key] ?? pd.default;
+    }
+    localParams = p;
+
+    const s: Record<string, string | number> = {};
+    for (const sd of def.styles) {
+      s[sd.key] = saved?.styles[sd.key] ?? sd.default;
+    }
+    localStyles = s;
+  });
+
+  function apply() {
+    appStore.setIndicatorSettings(indicatorId, { ...localParams }, { ...localStyles });
+    onclose();
+  }
+
+  function reset() {
+    if (!def) return;
+    const p: Record<string, number> = {};
+    for (const pd of def.params) p[pd.key] = pd.default;
+    localParams = p;
+
+    const s: Record<string, string | number> = {};
+    for (const sd of def.styles) s[sd.key] = sd.default;
+    localStyles = s;
+  }
+</script>
+
+{#if def}
+  <div class="settings-panel">
+    <div class="header">
+      <span class="title">{def.name}</span>
+      <button class="close-btn" onclick={onclose} aria-label="Close">
+        <Icon path={mdiClose} size={16} />
+      </button>
+    </div>
+
+    {#if def.params.length > 0}
+      <div class="section">
+        <div class="section-label">Parameters</div>
+        {#each def.params as p}
+          <div class="field">
+            <label for="param-{p.key}">{p.label}</label>
+            <input
+              id="param-{p.key}"
+              type="number"
+              min={p.min}
+              max={p.max}
+              step={p.step ?? 1}
+              bind:value={localParams[p.key]}
+              class="num-input"
+            />
+          </div>
+        {/each}
+      </div>
+    {/if}
+
+    <div class="section">
+      <div class="section-label">Style</div>
+      {#each def.styles as s}
+        <div class="field">
+          <label for="style-{s.key}">{s.label}</label>
+          {#if s.type === 'color'}
+            <div class="color-field">
+              <input
+                id="style-{s.key}"
+                type="color"
+                value={String(localStyles[s.key]).startsWith('rgba') ? '#42a5f5' : String(localStyles[s.key])}
+                oninput={(e: Event) => { localStyles[s.key] = (e.target as HTMLInputElement).value; }}
+                class="color-input"
+              />
+              <span class="color-preview" style="background:{localStyles[s.key]}"></span>
+            </div>
+          {:else}
+            <select
+              id="style-{s.key}"
+              bind:value={localStyles[s.key]}
+              class="select-input"
+            >
+              <option value={1}>1px</option>
+              <option value={2}>2px</option>
+              <option value={3}>3px</option>
+              <option value={4}>4px</option>
+            </select>
+          {/if}
+        </div>
+      {/each}
+    </div>
+
+    <div class="actions">
+      <button class="btn reset" onclick={reset}>Reset</button>
+      <button class="btn apply" onclick={apply}>Apply</button>
+    </div>
+  </div>
+{/if}
+
+<style>
+  .settings-panel {
+    position: absolute;
+    z-index: 30;
+    top: calc(100% + 4px);
+    left: 0;
+    background: #131722;
+    border: 1px solid #1a2332;
+    border-radius: 6px;
+    box-shadow: 0 8px 24px rgba(0, 0, 0, 0.5);
+    width: 280px;
+    display: flex;
+    flex-direction: column;
+  }
+
+  .header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: 10px 12px;
+    border-bottom: 1px solid #1a2332;
+  }
+
+  .title {
+    font-size: 12px;
+    font-weight: 600;
+    color: #d1d4dc;
+  }
+
+  .close-btn {
+    background: transparent;
+    border: none;
+    color: #758696;
+    cursor: pointer;
+    padding: 2px;
+    border-radius: 3px;
+    display: flex;
+    align-items: center;
+  }
+
+  .close-btn:hover {
+    color: #d1d4dc;
+    background: rgba(255, 255, 255, 0.06);
+  }
+
+  .section {
+    padding: 8px 12px;
+    border-bottom: 1px solid #1a2332;
+  }
+
+  .section-label {
+    font-size: 10px;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.5px;
+    color: #758696;
+    margin-bottom: 8px;
+  }
+
+  .field {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    margin-bottom: 6px;
+  }
+
+  .field:last-child {
+    margin-bottom: 0;
+  }
+
+  .field label {
+    font-size: 11px;
+    color: #9ca3af;
+  }
+
+  .num-input {
+    width: 64px;
+    background: #0d0d1a;
+    border: 1px solid #1a2332;
+    color: #d1d4dc;
+    padding: 3px 6px;
+    border-radius: 3px;
+    font-size: 11px;
+    text-align: right;
+    font-family: inherit;
+    outline: none;
+  }
+
+  .num-input:focus {
+    border-color: #2962ff;
+  }
+
+  .color-field {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+  }
+
+  .color-input {
+    width: 24px;
+    height: 20px;
+    padding: 0;
+    border: 1px solid #1a2332;
+    border-radius: 3px;
+    cursor: pointer;
+    background: transparent;
+  }
+
+  .color-preview {
+    width: 28px;
+    height: 12px;
+    border-radius: 2px;
+    border: 1px solid rgba(255, 255, 255, 0.1);
+  }
+
+  .select-input {
+    background: #0d0d1a;
+    border: 1px solid #1a2332;
+    color: #d1d4dc;
+    padding: 3px 6px;
+    border-radius: 3px;
+    font-size: 11px;
+    font-family: inherit;
+    outline: none;
+    cursor: pointer;
+  }
+
+  .select-input:focus {
+    border-color: #2962ff;
+  }
+
+  .actions {
+    display: flex;
+    justify-content: flex-end;
+    gap: 6px;
+    padding: 8px 12px;
+  }
+
+  .btn {
+    padding: 4px 12px;
+    border: none;
+    border-radius: 4px;
+    font-size: 11px;
+    cursor: pointer;
+    font-family: inherit;
+  }
+
+  .btn.reset {
+    background: transparent;
+    color: #758696;
+    border: 1px solid #1a2332;
+  }
+
+  .btn.reset:hover {
+    color: #d1d4dc;
+    background: rgba(255, 255, 255, 0.04);
+  }
+
+  .btn.apply {
+    background: #2962ff;
+    color: #fff;
+  }
+
+  .btn.apply:hover {
+    background: #1e50d9;
+  }
+</style>

--- a/dev/components/Toolbar/SymbolSearch.svelte
+++ b/dev/components/Toolbar/SymbolSearch.svelte
@@ -1,6 +1,8 @@
 <script lang="ts">
   import { searchSymbols } from '../../data/symbols';
   import { appStore } from '../../data/store.svelte.ts';
+  import Icon from '../Icon.svelte';
+  import { mdiMagnify } from '@mdi/js';
 
   let open = $state(false);
   let query = $state('');
@@ -45,6 +47,7 @@
 
 <div class="symbol-search" bind:this={containerEl}>
   <button class="trigger" onclick={toggle}>
+    <Icon path={mdiMagnify} size={14} />
     {appStore.symbol}
   </button>
 
@@ -81,6 +84,9 @@
   }
 
   .trigger {
+    display: flex;
+    align-items: center;
+    gap: 4px;
     padding: 4px 10px;
     background: #1a2332;
     border: 1px solid transparent;

--- a/dev/components/Toolbar/TimezoneSelector.svelte
+++ b/dev/components/Toolbar/TimezoneSelector.svelte
@@ -1,5 +1,7 @@
 <script lang="ts">
   import { appStore, TIMEZONE_OPTIONS } from '../../data/store.svelte.ts';
+  import Icon from '../Icon.svelte';
+  import { mdiEarth } from '@mdi/js';
 
   let open = $state(false);
   let containerEl: HTMLDivElement | undefined;
@@ -31,6 +33,7 @@
 
 <div class="timezone-selector" bind:this={containerEl}>
   <button class="trigger" onclick={() => (open = !open)}>
+    <Icon path={mdiEarth} size={14} />
     {currentLabel}
   </button>
 
@@ -56,6 +59,9 @@
   }
 
   .trigger {
+    display: flex;
+    align-items: center;
+    gap: 4px;
     background: transparent;
     border: 1px solid transparent;
     color: #758696;

--- a/dev/components/Toolbar/UtilityButtons.svelte
+++ b/dev/components/Toolbar/UtilityButtons.svelte
@@ -1,4 +1,7 @@
 <script lang="ts">
+  import Icon from '../Icon.svelte';
+  import { mdiFullscreen, mdiCamera, mdiCogOutline } from '@mdi/js';
+
   interface Props {
     onfullscreen?: () => void;
     onscreenshot?: () => void;
@@ -10,13 +13,13 @@
 
 <div class="utility-buttons">
   <button class="util-btn" title="Fullscreen" aria-label="Fullscreen" onclick={onfullscreen}>
-    &#x26F6;
+    <Icon path={mdiFullscreen} size={18} />
   </button>
   <button class="util-btn" title="Screenshot" aria-label="Screenshot" onclick={onscreenshot}>
-    &#x1F4F7;
+    <Icon path={mdiCamera} size={18} />
   </button>
   <button class="util-btn" title="Settings" aria-label="Settings" onclick={onsettings}>
-    &#x2699;
+    <Icon path={mdiCogOutline} size={18} />
   </button>
 </div>
 
@@ -37,6 +40,8 @@
     font-size: 14px;
     font-family: inherit;
     line-height: 1;
+    display: flex;
+    align-items: center;
   }
 
   .util-btn:hover {

--- a/dev/components/TradingViewApp.svelte
+++ b/dev/components/TradingViewApp.svelte
@@ -2,9 +2,10 @@
   import { onMount, onDestroy } from 'svelte';
   import { createChart } from 'fin-charter';
   import type { IChartApi, ISeriesApi, SeriesType, IndicatorType } from 'fin-charter';
-  import { fetchBars } from '../data/yahoo-finance';
+  import { fetchBars, fetchMoreBars } from '../data/yahoo-finance';
   import { appStore, CHART_TYPE_TO_SERIES } from '../data/store.svelte.ts';
   import type { ChartTypeLabel } from '../data/store.svelte.ts';
+  import { stylesToColorMap } from '../data/indicator-settings';
   import Toolbar from './Toolbar/Toolbar.svelte';
   import Sidebar from './Sidebar/Sidebar.svelte';
   import StatusBar from './StatusBar/StatusBar.svelte';
@@ -20,6 +21,8 @@
   let prevPeriodicity = '';
   let prevChartType: ChartTypeLabel = 'Candlestick';
   let loadRequestId = 0;
+  let isFetchingHistory = false;
+  let allBars: import('fin-charter').Bar[] = [];
 
   function createSeries(c: IChartApi, type: ChartTypeLabel): ISeriesApi<SeriesType> {
     const seriesType: SeriesType = CHART_TYPE_TO_SERIES[type] ?? 'candlestick';
@@ -45,6 +48,7 @@
         symbol: appStore.symbol,
       });
 
+      allBars = bars;
       mainSeries.setData(bars);
       chart.timeScale().scrollToEnd();
       // Comparisons are loaded by the comparison $effect — no need to duplicate here
@@ -101,8 +105,16 @@
     for (const id of desired) {
       if (!indicatorApis.has(id)) {
         try {
+          const settings = appStore.indicatorSettings[id];
+          const colors = settings ? stylesToColorMap(id, settings.styles) : undefined;
           const api = chart.addIndicator(id as IndicatorType, {
             source: mainSeries,
+            ...(settings?.params && Object.keys(settings.params).length > 0 ? { params: settings.params } : {}),
+            ...(colors ? { colors } : {}),
+            ...(settings?.styles.lineWidth ? { lineWidth: Number(settings.styles.lineWidth) } : {}),
+            ...(settings?.styles.histUpColor ? { histogramUpColor: String(settings.styles.histUpColor) } : {}),
+            ...(settings?.styles.histDownColor ? { histogramDownColor: String(settings.styles.histDownColor) } : {}),
+            ...(settings?.styles.color ? { color: String(settings.styles.color) } : {}),
           });
           indicatorApis.set(id, api);
         } catch (err) {
@@ -145,6 +157,27 @@
     prevChartType = appStore.chartType;
     prevSymbol = appStore.symbol;
     prevPeriodicity = appStore.periodicityLabel;
+
+    // Auto-load historical data when scrolling to the left edge
+    c.subscribeVisibleRangeChange(async (range) => {
+      if (!range || isFetchingHistory || allBars.length === 0 || !mainSeries) return;
+      const firstBarTime = allBars[0].time;
+      if (range.from <= firstBarTime) {
+        isFetchingHistory = true;
+        try {
+          const olderBars = await fetchMoreBars(appStore.symbol, appStore.periodicity, firstBarTime);
+          // Guard: only apply if symbol/periodicity haven't changed while fetching
+          if (olderBars.length > 0 && mainSeries && allBars.length > 0 && allBars[0].time === firstBarTime) {
+            allBars = [...olderBars, ...allBars];
+            mainSeries.setData(allBars);
+          }
+        } catch (err) {
+          console.error('Failed to load historical data:', err);
+        } finally {
+          isFetchingHistory = false;
+        }
+      }
+    });
 
     loadData();
   }
@@ -199,10 +232,19 @@
     }
   });
 
-  // React to indicator changes
+  // React to indicator changes (including settings updates)
   $effect(() => {
-    // Access the array to track it
+    // Access both to track changes
     const _indicators = appStore.activeIndicators;
+    const _settings = appStore.indicatorSettings;
+
+    // Remove all existing indicators and re-add with current settings
+    if (chart) {
+      for (const [id, api] of indicatorApis) {
+        chart.removeIndicator(api);
+      }
+      indicatorApis.clear();
+    }
     syncIndicators();
   });
 

--- a/dev/data/indicator-settings.ts
+++ b/dev/data/indicator-settings.ts
@@ -1,0 +1,457 @@
+/**
+ * Per-indicator settings definitions: computational params + visual styles.
+ *
+ * Each indicator has:
+ *  - `params`: numeric inputs (period, stdDev, etc.)
+ *  - `styles`: per-output visual config (color, lineWidth, plus histogram/fill options)
+ */
+
+export interface ParamDef {
+  key: string;
+  label: string;
+  default: number;
+  min?: number;
+  max?: number;
+  step?: number;
+}
+
+export interface StyleDef {
+  key: string;
+  label: string;
+  type: 'color' | 'lineWidth';
+  default: string | number;
+}
+
+export interface IndicatorSettingsDef {
+  id: string;
+  name: string;
+  params: ParamDef[];
+  styles: StyleDef[];
+}
+
+export const INDICATOR_SETTINGS: Record<string, IndicatorSettingsDef> = {
+  sma: {
+    id: 'sma',
+    name: 'Simple Moving Average',
+    params: [
+      { key: 'period', label: 'Period', default: 20, min: 1, max: 500 },
+    ],
+    styles: [
+      { key: 'color', label: 'Line', type: 'color', default: '#2962ff' },
+      { key: 'lineWidth', label: 'Line Width', type: 'lineWidth', default: 2 },
+    ],
+  },
+  ema: {
+    id: 'ema',
+    name: 'Exponential Moving Average',
+    params: [
+      { key: 'period', label: 'Period', default: 20, min: 1, max: 500 },
+    ],
+    styles: [
+      { key: 'color', label: 'Line', type: 'color', default: '#2962ff' },
+      { key: 'lineWidth', label: 'Line Width', type: 'lineWidth', default: 2 },
+    ],
+  },
+  bollinger: {
+    id: 'bollinger',
+    name: 'Bollinger Bands',
+    params: [
+      { key: 'period', label: 'Period', default: 20, min: 1, max: 500 },
+      { key: 'stdDev', label: 'Std Dev', default: 2, min: 0.1, max: 5, step: 0.1 },
+    ],
+    styles: [
+      { key: 'upperColor', label: 'Upper Band', type: 'color', default: '#42a5f5' },
+      { key: 'middleColor', label: 'Middle Line', type: 'color', default: '#2962ff' },
+      { key: 'lowerColor', label: 'Lower Band', type: 'color', default: '#42a5f5' },
+      { key: 'backgroundColor', label: 'Fill', type: 'color', default: 'rgba(66,165,245,0.1)' },
+      { key: 'lineWidth', label: 'Line Width', type: 'lineWidth', default: 2 },
+    ],
+  },
+  vwap: {
+    id: 'vwap',
+    name: 'VWAP',
+    params: [],
+    styles: [
+      { key: 'color', label: 'Line', type: 'color', default: '#2962ff' },
+      { key: 'lineWidth', label: 'Line Width', type: 'lineWidth', default: 2 },
+    ],
+  },
+  ichimoku: {
+    id: 'ichimoku',
+    name: 'Ichimoku Cloud',
+    params: [
+      { key: 'tenkanPeriod', label: 'Tenkan Period', default: 9, min: 1, max: 100 },
+      { key: 'kijunPeriod', label: 'Kijun Period', default: 26, min: 1, max: 100 },
+      { key: 'senkouPeriod', label: 'Senkou Period', default: 52, min: 1, max: 200 },
+    ],
+    styles: [
+      { key: 'tenkanColor', label: 'Tenkan-sen', type: 'color', default: '#2962ff' },
+      { key: 'kijunColor', label: 'Kijun-sen', type: 'color', default: '#F7525F' },
+      { key: 'senkouAColor', label: 'Senkou A', type: 'color', default: '#22AB94' },
+      { key: 'senkouBColor', label: 'Senkou B', type: 'color', default: '#ee6823' },
+      { key: 'chikouColor', label: 'Chikou', type: 'color', default: '#9c27b0' },
+      { key: 'lineWidth', label: 'Line Width', type: 'lineWidth', default: 2 },
+    ],
+  },
+  'parabolic-sar': {
+    id: 'parabolic-sar',
+    name: 'Parabolic SAR',
+    params: [
+      { key: 'afStep', label: 'AF Step', default: 0.02, min: 0.001, max: 0.1, step: 0.001 },
+      { key: 'afMax', label: 'AF Max', default: 0.20, min: 0.01, max: 1, step: 0.01 },
+    ],
+    styles: [
+      { key: 'color', label: 'Dots', type: 'color', default: '#2962ff' },
+      { key: 'lineWidth', label: 'Size', type: 'lineWidth', default: 2 },
+    ],
+  },
+  keltner: {
+    id: 'keltner',
+    name: 'Keltner Channel',
+    params: [
+      { key: 'emaPeriod', label: 'EMA Period', default: 20, min: 1, max: 500 },
+      { key: 'atrPeriod', label: 'ATR Period', default: 10, min: 1, max: 100 },
+      { key: 'multiplier', label: 'Multiplier', default: 2, min: 0.1, max: 10, step: 0.1 },
+    ],
+    styles: [
+      { key: 'upperColor', label: 'Upper Band', type: 'color', default: '#42a5f5' },
+      { key: 'middleColor', label: 'Middle Line', type: 'color', default: '#2962ff' },
+      { key: 'lowerColor', label: 'Lower Band', type: 'color', default: '#42a5f5' },
+      { key: 'backgroundColor', label: 'Fill', type: 'color', default: 'rgba(66,165,245,0.1)' },
+      { key: 'lineWidth', label: 'Line Width', type: 'lineWidth', default: 2 },
+    ],
+  },
+  donchian: {
+    id: 'donchian',
+    name: 'Donchian Channel',
+    params: [
+      { key: 'period', label: 'Period', default: 20, min: 1, max: 500 },
+    ],
+    styles: [
+      { key: 'upperColor', label: 'Upper Band', type: 'color', default: '#42a5f5' },
+      { key: 'middleColor', label: 'Middle Line', type: 'color', default: '#2962ff' },
+      { key: 'lowerColor', label: 'Lower Band', type: 'color', default: '#42a5f5' },
+      { key: 'backgroundColor', label: 'Fill', type: 'color', default: 'rgba(66,165,245,0.1)' },
+      { key: 'lineWidth', label: 'Line Width', type: 'lineWidth', default: 2 },
+    ],
+  },
+  supertrend: {
+    id: 'supertrend',
+    name: 'Supertrend',
+    params: [
+      { key: 'period', label: 'Period', default: 10, min: 1, max: 100 },
+      { key: 'multiplier', label: 'Multiplier', default: 3, min: 0.1, max: 10, step: 0.1 },
+    ],
+    styles: [
+      { key: 'color', label: 'Line', type: 'color', default: '#2962ff' },
+      { key: 'lineWidth', label: 'Line Width', type: 'lineWidth', default: 2 },
+    ],
+  },
+  vwma: {
+    id: 'vwma',
+    name: 'Volume Weighted MA',
+    params: [
+      { key: 'period', label: 'Period', default: 20, min: 1, max: 500 },
+    ],
+    styles: [
+      { key: 'color', label: 'Line', type: 'color', default: '#2962ff' },
+      { key: 'lineWidth', label: 'Line Width', type: 'lineWidth', default: 2 },
+    ],
+  },
+  'linear-regression': {
+    id: 'linear-regression',
+    name: 'Linear Regression',
+    params: [
+      { key: 'period', label: 'Period', default: 20, min: 1, max: 500 },
+    ],
+    styles: [
+      { key: 'color', label: 'Line', type: 'color', default: '#2962ff' },
+      { key: 'lineWidth', label: 'Line Width', type: 'lineWidth', default: 2 },
+    ],
+  },
+  rsi: {
+    id: 'rsi',
+    name: 'Relative Strength Index',
+    params: [
+      { key: 'period', label: 'Period', default: 14, min: 1, max: 100 },
+    ],
+    styles: [
+      { key: 'color', label: 'RSI Line', type: 'color', default: '#2962ff' },
+      { key: 'lineWidth', label: 'Line Width', type: 'lineWidth', default: 2 },
+    ],
+  },
+  macd: {
+    id: 'macd',
+    name: 'MACD',
+    params: [
+      { key: 'fastPeriod', label: 'Fast Period', default: 12, min: 1, max: 100 },
+      { key: 'slowPeriod', label: 'Slow Period', default: 26, min: 1, max: 200 },
+      { key: 'signalPeriod', label: 'Signal Period', default: 9, min: 1, max: 100 },
+    ],
+    styles: [
+      { key: 'macdColor', label: 'MACD Line', type: 'color', default: '#2962ff' },
+      { key: 'signalColor', label: 'Signal Line', type: 'color', default: '#ff6d00' },
+      { key: 'histUpColor', label: 'Histogram Up', type: 'color', default: 'rgba(34,171,148,0.4)' },
+      { key: 'histDownColor', label: 'Histogram Down', type: 'color', default: 'rgba(247,82,95,0.4)' },
+      { key: 'lineWidth', label: 'Line Width', type: 'lineWidth', default: 2 },
+    ],
+  },
+  stochastic: {
+    id: 'stochastic',
+    name: 'Stochastic',
+    params: [
+      { key: 'kPeriod', label: '%K Period', default: 14, min: 1, max: 100 },
+      { key: 'dPeriod', label: '%D Period', default: 3, min: 1, max: 100 },
+    ],
+    styles: [
+      { key: 'kColor', label: '%K Line', type: 'color', default: '#2962ff' },
+      { key: 'dColor', label: '%D Line', type: 'color', default: '#ff6d00' },
+      { key: 'lineWidth', label: 'Line Width', type: 'lineWidth', default: 2 },
+    ],
+  },
+  atr: {
+    id: 'atr',
+    name: 'Average True Range',
+    params: [
+      { key: 'period', label: 'Period', default: 14, min: 1, max: 100 },
+    ],
+    styles: [
+      { key: 'color', label: 'ATR Line', type: 'color', default: '#2962ff' },
+      { key: 'lineWidth', label: 'Line Width', type: 'lineWidth', default: 2 },
+    ],
+  },
+  adx: {
+    id: 'adx',
+    name: 'Average Directional Index',
+    params: [
+      { key: 'period', label: 'Period', default: 14, min: 1, max: 100 },
+    ],
+    styles: [
+      { key: 'adxColor', label: 'ADX Line', type: 'color', default: '#2962ff' },
+      { key: 'plusDIColor', label: '+DI Line', type: 'color', default: '#22AB94' },
+      { key: 'minusDIColor', label: '-DI Line', type: 'color', default: '#F7525F' },
+      { key: 'lineWidth', label: 'Line Width', type: 'lineWidth', default: 2 },
+    ],
+  },
+  obv: {
+    id: 'obv',
+    name: 'On-Balance Volume',
+    params: [],
+    styles: [
+      { key: 'color', label: 'OBV Line', type: 'color', default: '#2962ff' },
+      { key: 'lineWidth', label: 'Line Width', type: 'lineWidth', default: 2 },
+    ],
+  },
+  'williams-r': {
+    id: 'williams-r',
+    name: 'Williams %R',
+    params: [
+      { key: 'period', label: 'Period', default: 14, min: 1, max: 100 },
+    ],
+    styles: [
+      { key: 'color', label: 'Line', type: 'color', default: '#2962ff' },
+      { key: 'lineWidth', label: 'Line Width', type: 'lineWidth', default: 2 },
+    ],
+  },
+  cci: {
+    id: 'cci',
+    name: 'Commodity Channel Index',
+    params: [
+      { key: 'period', label: 'Period', default: 20, min: 1, max: 200 },
+    ],
+    styles: [
+      { key: 'color', label: 'CCI Line', type: 'color', default: '#2962ff' },
+      { key: 'lineWidth', label: 'Line Width', type: 'lineWidth', default: 2 },
+    ],
+  },
+  aroon: {
+    id: 'aroon',
+    name: 'Aroon',
+    params: [
+      { key: 'period', label: 'Period', default: 25, min: 1, max: 200 },
+    ],
+    styles: [
+      { key: 'upColor', label: 'Aroon Up', type: 'color', default: '#22AB94' },
+      { key: 'downColor', label: 'Aroon Down', type: 'color', default: '#F7525F' },
+      { key: 'lineWidth', label: 'Line Width', type: 'lineWidth', default: 2 },
+    ],
+  },
+  'awesome-oscillator': {
+    id: 'awesome-oscillator',
+    name: 'Awesome Oscillator',
+    params: [
+      { key: 'fastPeriod', label: 'Fast Period', default: 5, min: 1, max: 100 },
+      { key: 'slowPeriod', label: 'Slow Period', default: 34, min: 1, max: 200 },
+    ],
+    styles: [
+      { key: 'histUpColor', label: 'Histogram Up', type: 'color', default: 'rgba(34,171,148,0.4)' },
+      { key: 'histDownColor', label: 'Histogram Down', type: 'color', default: 'rgba(247,82,95,0.4)' },
+    ],
+  },
+  'chaikin-mf': {
+    id: 'chaikin-mf',
+    name: 'Chaikin Money Flow',
+    params: [
+      { key: 'period', label: 'Period', default: 20, min: 1, max: 200 },
+    ],
+    styles: [
+      { key: 'color', label: 'CMF Line', type: 'color', default: '#2962ff' },
+      { key: 'lineWidth', label: 'Line Width', type: 'lineWidth', default: 2 },
+    ],
+  },
+  coppock: {
+    id: 'coppock',
+    name: 'Coppock Curve',
+    params: [
+      { key: 'wmaPeriod', label: 'WMA Period', default: 10, min: 1, max: 100 },
+      { key: 'longROC', label: 'Long ROC', default: 14, min: 1, max: 100 },
+      { key: 'shortROC', label: 'Short ROC', default: 11, min: 1, max: 100 },
+    ],
+    styles: [
+      { key: 'color', label: 'Coppock Line', type: 'color', default: '#2962ff' },
+      { key: 'lineWidth', label: 'Line Width', type: 'lineWidth', default: 2 },
+    ],
+  },
+  'elder-force': {
+    id: 'elder-force',
+    name: 'Elder Force Index',
+    params: [
+      { key: 'period', label: 'Period', default: 13, min: 1, max: 100 },
+    ],
+    styles: [
+      { key: 'color', label: 'Force Line', type: 'color', default: '#2962ff' },
+      { key: 'lineWidth', label: 'Line Width', type: 'lineWidth', default: 2 },
+    ],
+  },
+  trix: {
+    id: 'trix',
+    name: 'TRIX',
+    params: [
+      { key: 'period', label: 'Period', default: 15, min: 1, max: 100 },
+      { key: 'signalPeriod', label: 'Signal Period', default: 9, min: 1, max: 100 },
+    ],
+    styles: [
+      { key: 'trixColor', label: 'TRIX Line', type: 'color', default: '#2962ff' },
+      { key: 'signalColor', label: 'Signal Line', type: 'color', default: '#ff6d00' },
+      { key: 'lineWidth', label: 'Line Width', type: 'lineWidth', default: 2 },
+    ],
+  },
+  choppiness: {
+    id: 'choppiness',
+    name: 'Choppiness Index',
+    params: [
+      { key: 'period', label: 'Period', default: 14, min: 1, max: 100 },
+    ],
+    styles: [
+      { key: 'color', label: 'Line', type: 'color', default: '#2962ff' },
+      { key: 'lineWidth', label: 'Line Width', type: 'lineWidth', default: 2 },
+    ],
+  },
+  mfi: {
+    id: 'mfi',
+    name: 'Money Flow Index',
+    params: [
+      { key: 'period', label: 'Period', default: 14, min: 1, max: 100 },
+    ],
+    styles: [
+      { key: 'color', label: 'MFI Line', type: 'color', default: '#2962ff' },
+      { key: 'lineWidth', label: 'Line Width', type: 'lineWidth', default: 2 },
+    ],
+  },
+  roc: {
+    id: 'roc',
+    name: 'Rate of Change',
+    params: [
+      { key: 'period', label: 'Period', default: 12, min: 1, max: 200 },
+    ],
+    styles: [
+      { key: 'color', label: 'ROC Line', type: 'color', default: '#2962ff' },
+      { key: 'lineWidth', label: 'Line Width', type: 'lineWidth', default: 2 },
+    ],
+  },
+  'pivot-points': {
+    id: 'pivot-points',
+    name: 'Pivot Points',
+    params: [],
+    styles: [
+      { key: 'ppColor', label: 'Pivot (PP)', type: 'color', default: '#2962ff' },
+      { key: 'resistanceColor', label: 'Resistance (R1-R3)', type: 'color', default: '#F7525F' },
+      { key: 'supportColor', label: 'Support (S1-S3)', type: 'color', default: '#22AB94' },
+      { key: 'lineWidth', label: 'Line Width', type: 'lineWidth', default: 2 },
+    ],
+  },
+};
+
+/** Build the colors map expected by the library from user style settings. */
+export function stylesToColorMap(
+  indicatorId: string,
+  styles: Record<string, string | number>,
+): Record<string, string> | undefined {
+  switch (indicatorId) {
+    case 'bollinger':
+      return {
+        upper: (styles.upperColor as string) ?? '#42a5f5',
+        middle: (styles.middleColor as string) ?? '#2962ff',
+        lower: (styles.lowerColor as string) ?? '#42a5f5',
+      };
+    case 'macd':
+      return {
+        macd: (styles.macdColor as string) ?? '#2962ff',
+        signal: (styles.signalColor as string) ?? '#ff6d00',
+        histogram: (styles.histUpColor as string) ?? 'rgba(34,171,148,0.4)',
+      };
+    case 'stochastic':
+      return {
+        k: (styles.kColor as string) ?? '#2962ff',
+        d: (styles.dColor as string) ?? '#ff6d00',
+      };
+    case 'adx':
+      return {
+        adx: (styles.adxColor as string) ?? '#2962ff',
+        plusDI: (styles.plusDIColor as string) ?? '#22AB94',
+        minusDI: (styles.minusDIColor as string) ?? '#F7525F',
+      };
+    case 'ichimoku':
+      return {
+        tenkan: (styles.tenkanColor as string) ?? '#2962ff',
+        kijun: (styles.kijunColor as string) ?? '#F7525F',
+        senkouA: (styles.senkouAColor as string) ?? '#22AB94',
+        senkouB: (styles.senkouBColor as string) ?? '#ee6823',
+        chikou: (styles.chikouColor as string) ?? '#9c27b0',
+      };
+    case 'keltner':
+      return {
+        upper: (styles.upperColor as string) ?? '#42a5f5',
+        middle: (styles.middleColor as string) ?? '#2962ff',
+        lower: (styles.lowerColor as string) ?? '#42a5f5',
+      };
+    case 'donchian':
+      return {
+        upper: (styles.upperColor as string) ?? '#42a5f5',
+        middle: (styles.middleColor as string) ?? '#2962ff',
+        lower: (styles.lowerColor as string) ?? '#42a5f5',
+      };
+    case 'pivot-points':
+      return {
+        pp: (styles.ppColor as string) ?? '#2962ff',
+        r1: (styles.resistanceColor as string) ?? '#F7525F',
+        r2: (styles.resistanceColor as string) ?? '#F7525F',
+        r3: (styles.resistanceColor as string) ?? '#F7525F',
+        s1: (styles.supportColor as string) ?? '#22AB94',
+        s2: (styles.supportColor as string) ?? '#22AB94',
+        s3: (styles.supportColor as string) ?? '#22AB94',
+      };
+    case 'aroon':
+      return {
+        up: (styles.upColor as string) ?? '#22AB94',
+        down: (styles.downColor as string) ?? '#F7525F',
+      };
+    case 'trix':
+      return {
+        trix: (styles.trixColor as string) ?? '#2962ff',
+        signal: (styles.signalColor as string) ?? '#ff6d00',
+      };
+    default:
+      return undefined;
+  }
+}

--- a/dev/data/store.svelte.ts
+++ b/dev/data/store.svelte.ts
@@ -50,6 +50,7 @@ let _sidebarOpen = $state(true);
 let _comparisonMode = $state(false);
 let _comparisonSymbols = $state<string[]>([]);
 let _activeIndicators = $state<string[]>([]);
+let _indicatorSettings = $state<Record<string, { params: Record<string, number>; styles: Record<string, string | number> }>>({});
 let _activeDrawingTool = $state<string | null>(null);
 let _meta = $state<QuoteMeta | null>(null);
 let _loading = $state(false);
@@ -83,7 +84,16 @@ export const appStore = {
 
   get activeIndicators() { return _activeIndicators; },
   addIndicator(id: string) { _activeIndicators = [..._activeIndicators, id]; },
-  removeIndicator(id: string) { _activeIndicators = _activeIndicators.filter(i => i !== id); },
+  removeIndicator(id: string) {
+    _activeIndicators = _activeIndicators.filter(i => i !== id);
+    const { [id]: _, ...rest } = _indicatorSettings;
+    _indicatorSettings = rest;
+  },
+
+  get indicatorSettings() { return _indicatorSettings; },
+  setIndicatorSettings(id: string, params: Record<string, number>, styles: Record<string, string | number>) {
+    _indicatorSettings = { ..._indicatorSettings, [id]: { params, styles } };
+  },
 
   get activeDrawingTool() { return _activeDrawingTool; },
   set activeDrawingTool(v: string | null) { _activeDrawingTool = v; },

--- a/dev/data/yahoo-finance.ts
+++ b/dev/data/yahoo-finance.ts
@@ -41,6 +41,33 @@ const INTERVAL_MAP: Record<string, { interval: string; range: string }> = {
   '1M':  { interval: '1mo', range: 'max' },
 };
 
+/**
+ * Yahoo Finance API absolute limits: max seconds from NOW for each interval.
+ * Requests with period1 older than now - limit will fail.
+ */
+const YAHOO_MAX_AGE: Record<string, number> = {
+  '1m':  7 * 86400,         // ~7 days
+  '5m':  60 * 86400,        // 60 days
+  '15m': 60 * 86400,        // 60 days
+  '1h':  730 * 86400,       // ~2 years
+  '4h':  730 * 86400,       // same as 1h (fetches 1h then aggregates)
+  '1D':  0,                 // unlimited (0 = no limit)
+  '1W':  0,                 // unlimited
+  '1M':  0,                 // unlimited
+};
+
+/** Per-request chunk size (seconds) to stay within Yahoo's per-request limits. */
+const REQUEST_CHUNK: Record<string, number> = {
+  '1m':  0,                // no extra history for 1m
+  '5m':  30 * 86400,       // 30 days per chunk
+  '15m': 30 * 86400,       // 30 days per chunk
+  '1h':  90 * 86400,       // 90 days per chunk
+  '4h':  180 * 86400,      // 180 days per chunk
+  '1D':  365 * 86400,      // 1 year per chunk
+  '1W':  5 * 365 * 86400,  // 5 years per chunk
+  '1M':  10 * 365 * 86400, // 10 years per chunk
+};
+
 function periodicityToKey(p: Periodicity): string {
   const map: Record<string, string> = {
     minute: 'm', hour: 'h', day: 'D', week: 'W', month: 'M',
@@ -118,6 +145,119 @@ export async function fetchBars(
   };
 
   return { bars: finalBars, meta };
+}
+
+/** Fetch a single chunk of bars for a given period1/period2 range. */
+async function fetchChunk(
+  symbol: string,
+  yahooInterval: string,
+  period1: number,
+  period2: number,
+  beforeTimestamp: number,
+): Promise<Bar[]> {
+  const url =
+    `/api/yahoo/${encodeURIComponent(symbol)}?interval=${yahooInterval}` +
+    `&period1=${Math.floor(period1)}&period2=${Math.floor(period2)}`;
+
+  let resp: Response;
+  try {
+    resp = await fetch(url);
+  } catch {
+    return [];
+  }
+  if (!resp.ok) return [];
+
+  let result: (YahooQuote & { meta?: YahooMeta }) | undefined;
+  try {
+    const json = await resp.json();
+    result = json.chart?.result?.[0];
+  } catch {
+    return [];
+  }
+  if (!result) return [];
+
+  const timestamps = result.timestamp ?? [];
+  const ohlcv = result.indicators?.quote?.[0];
+  if (!ohlcv || timestamps.length === 0) return [];
+
+  const bars: Bar[] = [];
+  for (let i = 0; i < timestamps.length; i++) {
+    const o = ohlcv.open[i];
+    const h = ohlcv.high[i];
+    const l = ohlcv.low[i];
+    const c = ohlcv.close[i];
+    const v = ohlcv.volume[i];
+    if (o == null || h == null || l == null || c == null) continue;
+    if (timestamps[i] >= beforeTimestamp) continue;
+    bars.push({ time: timestamps[i], open: o, high: h, low: l, close: c, volume: v ?? 0 });
+  }
+  return bars;
+}
+
+/**
+ * Fetch older bars that precede `beforeTimestamp`.
+ *
+ * Respects Yahoo Finance API limits per interval and makes multiple chunked
+ * requests when the desired range exceeds a single request's capacity.
+ * Returns an empty array if the periodicity doesn't support further history.
+ */
+export async function fetchMoreBars(
+  symbol: string,
+  periodicity: Periodicity,
+  beforeTimestamp: number,
+): Promise<Bar[]> {
+  const key = periodicityToKey(periodicity);
+  const chunkSize = REQUEST_CHUNK[key] ?? 0;
+  if (chunkSize === 0) return [];
+
+  const yahooInterval = (INTERVAL_MAP[key] ?? INTERVAL_MAP['1D']).interval;
+
+  // Clamp the target period1 to Yahoo's absolute limit from now
+  const maxAge = YAHOO_MAX_AGE[key] ?? 0;
+  const now = Math.floor(Date.now() / 1000);
+  const absoluteFloor = maxAge > 0 ? now - maxAge : 0;
+
+  // The farthest back we want to go in this load
+  let targetPeriod1 = beforeTimestamp - chunkSize;
+  if (absoluteFloor > 0 && targetPeriod1 < absoluteFloor) {
+    targetPeriod1 = absoluteFloor;
+  }
+
+  // Nothing to fetch if we've already reached the API limit
+  if (targetPeriod1 >= beforeTimestamp) return [];
+
+  // Break the total range into sub-chunks.
+  // Each sub-chunk stays within Yahoo's per-request granularity limits.
+  const subChunkSize = maxAge > 0 ? Math.min(chunkSize, maxAge) : chunkSize;
+  const allBars: Bar[] = [];
+  let currentEnd = beforeTimestamp;
+
+  while (currentEnd > targetPeriod1) {
+    const currentStart = Math.max(currentEnd - subChunkSize, targetPeriod1);
+    const chunk = await fetchChunk(symbol, yahooInterval, currentStart, currentEnd, beforeTimestamp);
+
+    if (chunk.length > 0) {
+      // Prepend this chunk (older data comes first)
+      allBars.unshift(...chunk);
+    } else {
+      // API returned nothing — no more history available
+      break;
+    }
+
+    currentEnd = currentStart;
+    // Avoid infinite loop if the chunk didn't move the window
+    if (currentEnd >= beforeTimestamp) break;
+  }
+
+  // Deduplicate by timestamp (in case chunks overlap)
+  const seen = new Set<number>();
+  const deduped = allBars.filter(b => {
+    if (seen.has(b.time)) return false;
+    seen.add(b.time);
+    return true;
+  });
+
+  return key === '4h' ? aggregate4h(deduped) : deduped;
 }
 
 // Fallback data for static builds (no proxy available)

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,9 @@
       "name": "fin-charter",
       "version": "0.1.0",
       "license": "MIT",
+      "dependencies": {
+        "@mdi/js": "^7.4.47"
+      },
       "devDependencies": {
         "@eslint/js": "^10.0.1",
         "@storybook/addon-docs": "^10.3.4",
@@ -1046,6 +1049,12 @@
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
+    },
+    "node_modules/@mdi/js": {
+      "version": "7.4.47",
+      "resolved": "https://registry.npmjs.org/@mdi/js/-/js-7.4.47.tgz",
+      "integrity": "sha512-KPnNOtm5i2pMabqZxpUz7iQf+mfrYZyKCZ8QNz85czgEt7cuHcGorWfdzUMWYA0SD+a6Hn4FmJ+YhzzzjkTZrQ==",
+      "license": "Apache-2.0"
     },
     "node_modules/@mdx-js/react": {
       "version": "3.1.1",

--- a/package.json
+++ b/package.json
@@ -100,5 +100,8 @@
     "vite": "^8.0.3",
     "vite-plugin-dts": "^4.5.4",
     "vitest": "^4.1.2"
+  },
+  "dependencies": {
+    "@mdi/js": "^7.4.47"
   }
 }

--- a/src/api/chart-api.ts
+++ b/src/api/chart-api.ts
@@ -1015,13 +1015,16 @@ class ChartApi implements IChartApi {
     // 5-6. Create internal series
     const color = options.color ?? '#2962ff';
     const lineWidth = options.lineWidth ?? 2;
+    const customColors = options.colors;
+    const histUpColor = options.histogramUpColor ?? 'rgba(34, 171, 148, 0.4)';
+    const histDownColor = options.histogramDownColor ?? 'rgba(247, 82, 95, 0.4)';
 
     const indicator = new IndicatorApi(id, type, options, paneId, () => {
       this.removeIndicator(indicator);
     });
     indicator.autoCreatedPaneId = autoCreatedPaneId;
 
-    this._createIndicatorSeries(indicator, result, store, paneId, color, lineWidth);
+    this._createIndicatorSeries(indicator, result, store, paneId, color, lineWidth, customColors, histUpColor, histDownColor);
 
     // 7. Subscribe to source's dataChanged for auto-recompute
     const dataChangedCallback = (): void => {
@@ -1035,7 +1038,7 @@ class ChartApi implements IChartApi {
       indicator.internalSeries = [];
 
       // Recreate with updated data
-      this._createIndicatorSeries(indicator, updatedResult, updatedStore, paneId, color, lineWidth);
+      this._createIndicatorSeries(indicator, updatedResult, updatedStore, paneId, color, lineWidth, customColors, histUpColor, histDownColor);
     };
     indicator._dataChangedCallback = dataChangedCallback;
     options.source.subscribeDataChanged(dataChangedCallback);
@@ -1194,11 +1197,15 @@ class ChartApi implements IChartApi {
     paneId: string,
     primaryColor: string,
     lineWidth: number,
+    customColors?: Record<string, string>,
+    histUpColor: string = 'rgba(34, 171, 148, 0.4)',
+    histDownColor: string = 'rgba(247, 82, 95, 0.4)',
   ): void {
     const type = indicator.indicatorType();
 
-    // Color map for multi-output indicators
-    const colorMap = this._getIndicatorColorMap(type, primaryColor);
+    // Color map for multi-output indicators — custom overrides take precedence
+    const defaultColorMap = this._getIndicatorColorMap(type, primaryColor);
+    const colorMap = customColors ? { ...defaultColorMap, ...customColors } : defaultColorMap;
 
     // Draw histogram series first so line series render on top
     const sortedKeys = Object.keys(result).sort((a, b) =>
@@ -1228,8 +1235,8 @@ class ChartApi implements IChartApi {
         series = this._addSeries('histogram', {
           paneId,
           data: bars,
-          upColor: 'rgba(34, 171, 148, 0.4)',
-          downColor: 'rgba(247, 82, 95, 0.4)',
+          upColor: histUpColor,
+          downColor: histDownColor,
         }, true);
       } else {
         series = this._addSeries('line', {

--- a/src/api/options.ts
+++ b/src/api/options.ts
@@ -269,6 +269,12 @@ export interface IndicatorOptions {
   lineWidth?: number;
   visible?: boolean;
   label?: string;
+  /** Per-output color overrides, e.g. { upper: '#ff0', middle: '#0f0', lower: '#ff0' }. */
+  colors?: Record<string, string>;
+  /** Histogram up-bar color override (default: green). */
+  histogramUpColor?: string;
+  /** Histogram down-bar color override (default: red). */
+  histogramDownColor?: string;
 }
 
 export const OVERLAY_INDICATORS: Set<IndicatorType> = new Set([


### PR DESCRIPTION
## Summary
- Auto-load historical data when scrolling left with chunked Yahoo Finance requests respecting per-interval API limits (7d for 1m, 60d for 5m/15m, 730d for 1h, unlimited for daily+)
- Add per-indicator settings UI with configurable params (period, stdDev, multiplier) and per-output color/lineWidth controls for all 30 indicators
- Extend `IndicatorOptions` with `colors`, `histogramUpColor`, `histogramDownColor` for custom per-output color maps
- Replace all emoji/unicode icons with Material Design Icons (`@mdi/js`) across toolbar, sidebar, and status bar

## Test plan
- [ ] Scroll left on daily chart — verify historical data auto-loads seamlessly
- [ ] Scroll left on 5m chart — verify it respects 60-day Yahoo API limit
- [ ] Add Bollinger Bands, click gear icon, change upper/lower band colors — verify chart updates
- [ ] Add MACD, configure histogram up/down colors and signal line color
- [ ] Verify all toolbar icons render as SVG (no emoji/unicode)
- [ ] Verify Storybook TradingView story includes all features

🤖 Generated with [Claude Code](https://claude.com/claude-code)