### PR TITLE
docs: add inline documentation to all Storybook stories

### DIFF
--- a/stories/AllChartTypes.stories.ts
+++ b/stories/AllChartTypes.stories.ts
@@ -1,6 +1,7 @@
 import type { Meta, StoryObj } from '@storybook/html';
 import { createChart } from 'fin-charter';
 import { AAPL_DAILY } from './sample-data';
+import { withDocs } from './doc-renderer';
 
 const meta: Meta = {
   title: 'Chart Types/All Chart Types',
@@ -153,6 +154,25 @@ chart.addBaselineSeries().setData(data);
       root.appendChild(makePanel(spec));
     }
 
-    return root;
+    return withDocs(root, {
+      description:
+        'fin-charter supports <strong>6 chart types</strong> out of the box. Each type uses the same OHLCV data format ' +
+        'but renders it differently. Use <code>addCandlestickSeries()</code>, <code>addHollowCandleSeries()</code>, ' +
+        '<code>addBarSeries()</code>, <code>addLineSeries()</code>, <code>addAreaSeries()</code>, or <code>addBaselineSeries()</code> ' +
+        'to create the type you need.',
+      code: `
+import { createChart } from 'fin-charter';
+
+const chart = createChart(container, { autoSize: true, symbol: 'AAPL' });
+
+// Pick the series type that fits your use case:
+chart.addCandlestickSeries().setData(data);   // Classic OHLC candles
+chart.addHollowCandleSeries().setData(data);  // Hollow bullish / filled bearish
+chart.addBarSeries().setData(data);            // Traditional OHLC bars
+chart.addLineSeries().setData(data);           // Close-price polyline
+chart.addAreaSeries().setData(data);           // Line with gradient fill
+chart.addBaselineSeries().setData(data);       // Split above/below reference price
+      `,
+    });
   },
 };

--- a/stories/AreaChart.stories.ts
+++ b/stories/AreaChart.stories.ts
@@ -2,6 +2,7 @@ import type { Meta, StoryObj } from '@storybook/html';
 import { createChart } from 'fin-charter';
 import { createChartContainer } from './helpers';
 import { AAPL_DAILY } from './sample-data';
+import { withDocs } from './doc-renderer';
 
 const meta: Meta = {
   title: 'Chart Types/Area',
@@ -37,7 +38,21 @@ series.setData(data);
     const chart = createChart(container, { autoSize: true, symbol: 'AAPL' });
     const series = chart.addAreaSeries();
     series.setData(AAPL_DAILY);
-    return container;
+    return withDocs(container, {
+      description:
+        'An <strong>area chart</strong> renders a line at the close price with a gradient fill extending down to the bottom of the chart. ' +
+        'It provides a clear visual sense of magnitude and is often used for portfolio value or index tracking.',
+      code: `
+import { createChart } from 'fin-charter';
+
+const chart = createChart(document.getElementById('chart'), {
+  autoSize: true,
+  symbol: 'AAPL',
+});
+const series = chart.addAreaSeries();
+series.setData(data);
+      `,
+    });
   },
 };
 
@@ -66,6 +81,18 @@ series.setData(data);
       bottomColor: 'rgba(0, 229, 255, 0.0)',
     });
     series.setData(AAPL_DAILY);
-    return container;
+    return withDocs(container, {
+      description:
+        'Customize the area gradient with <code>lineColor</code>, <code>topColor</code>, and <code>bottomColor</code>. ' +
+        'Use RGBA values for <code>topColor</code> / <code>bottomColor</code> to control the gradient opacity.',
+      code: `
+const series = chart.addAreaSeries({
+  lineColor: '#00e5ff',                    // Line at the top of the area
+  topColor: 'rgba(0, 229, 255, 0.4)',      // Gradient start (near line)
+  bottomColor: 'rgba(0, 229, 255, 0.0)',   // Gradient end (transparent)
+});
+series.setData(data);
+      `,
+    });
   },
 };

--- a/stories/BarChart.stories.ts
+++ b/stories/BarChart.stories.ts
@@ -2,6 +2,7 @@ import type { Meta, StoryObj } from '@storybook/html';
 import { createChart } from 'fin-charter';
 import { createChartContainer } from './helpers';
 import { AAPL_DAILY } from './sample-data';
+import { withDocs } from './doc-renderer';
 
 const meta: Meta = {
   title: 'Chart Types/OHLC Bar',
@@ -37,7 +38,21 @@ series.setData(data);
     const chart = createChart(container, { autoSize: true, symbol: 'AAPL' });
     const series = chart.addBarSeries();
     series.setData(AAPL_DAILY);
-    return container;
+    return withDocs(container, {
+      description:
+        'The <strong>OHLC bar chart</strong> displays each period as a vertical bar with tick marks for open (left) and close (right). ' +
+        'The bar extends from the high to the low price. This is a traditional chart type favored by commodity and futures traders.',
+      code: `
+import { createChart } from 'fin-charter';
+
+const chart = createChart(document.getElementById('chart'), {
+  autoSize: true,
+  symbol: 'AAPL',
+});
+const series = chart.addBarSeries();
+series.setData(data);
+      `,
+    });
   },
 };
 
@@ -64,6 +79,17 @@ series.setData(data);
       downColor: '#F7525F',
     });
     series.setData(AAPL_DAILY);
-    return container;
+    return withDocs(container, {
+      description:
+        'Customize the up/down bar colors with <code>upColor</code> and <code>downColor</code>. ' +
+        'Bullish bars (close &gt; open) use <code>upColor</code> and bearish bars use <code>downColor</code>.',
+      code: `
+const series = chart.addBarSeries({
+  upColor: '#22AB94',   // Bullish bars
+  downColor: '#F7525F', // Bearish bars
+});
+series.setData(data);
+      `,
+    });
   },
 };

--- a/stories/BaselineChart.stories.ts
+++ b/stories/BaselineChart.stories.ts
@@ -2,6 +2,7 @@ import type { Meta, StoryObj } from '@storybook/html';
 import { createChart } from 'fin-charter';
 import { createChartContainer } from './helpers';
 import { AAPL_DAILY } from './sample-data';
+import { withDocs } from './doc-renderer';
 
 const meta: Meta = {
   title: 'Chart Types/Baseline',
@@ -38,7 +39,22 @@ series.setData(data);
     const chart = createChart(container, { autoSize: true, symbol: 'AAPL' });
     const series = chart.addBaselineSeries();
     series.setData(AAPL_DAILY);
-    return container;
+    return withDocs(container, {
+      description:
+        'A <strong>baseline chart</strong> splits the price area into two color zones around a reference price. ' +
+        'Areas above the baseline are filled with one color and areas below with another, making it easy to see when an instrument is trading above or below a key level.\n' +
+        'By default the baseline is set to the first data point\'s close price.',
+      code: `
+import { createChart } from 'fin-charter';
+
+const chart = createChart(document.getElementById('chart'), {
+  autoSize: true,
+  symbol: 'AAPL',
+});
+const series = chart.addBaselineSeries();
+series.setData(data);
+      `,
+    });
   },
 };
 
@@ -71,6 +87,20 @@ series.setData(data);
       bottomFillColor: 'rgba(255, 107, 107, 0.28)',
     });
     series.setData(AAPL_DAILY);
-    return container;
+    return withDocs(container, {
+      description:
+        'Set a custom <code>basePrice</code> to define the split point. Configure the colors for each zone independently: ' +
+        '<code>topLineColor</code> / <code>topFillColor</code> for above the baseline, and <code>bottomLineColor</code> / <code>bottomFillColor</code> for below.',
+      code: `
+const series = chart.addBaselineSeries({
+  basePrice: 110,                                   // Split at $110
+  topLineColor: '#00e5ff',                          // Line above baseline
+  bottomLineColor: '#ff6b6b',                       // Line below baseline
+  topFillColor: 'rgba(0, 229, 255, 0.28)',          // Fill above baseline
+  bottomFillColor: 'rgba(255, 107, 107, 0.28)',     // Fill below baseline
+});
+series.setData(data);
+      `,
+    });
   },
 };

--- a/stories/CandlestickChart.stories.ts
+++ b/stories/CandlestickChart.stories.ts
@@ -2,6 +2,7 @@ import type { Meta, StoryObj } from '@storybook/html';
 import { createChart } from 'fin-charter';
 import { generateOHLCV, createChartContainer } from './helpers';
 import { AAPL_DAILY } from './sample-data';
+import { withDocs } from './doc-renderer';
 
 const meta: Meta = {
   title: 'Chart Types/Candlestick',
@@ -35,7 +36,22 @@ series.setData(data); // Array of { time, open, high, low, close, volume }`,
     const chart = createChart(container, { autoSize: true, symbol: 'AAPL' });
     const series = chart.addCandlestickSeries();
     series.setData(AAPL_DAILY);
-    return container;
+    return withDocs(container, {
+      description:
+        'The <strong>candlestick chart</strong> is the most common financial chart type, showing open, high, low, and close (OHLC) prices for each time period. ' +
+        'Green (bullish) candles indicate the close was higher than the open; red (bearish) candles indicate the close was lower.\n' +
+        'Pass an array of <code>{ time, open, high, low, close, volume }</code> objects to <code>series.setData()</code>.',
+      code: `
+import { createChart } from 'fin-charter';
+
+const chart = createChart(document.getElementById('chart'), {
+  autoSize: true,
+  symbol: 'AAPL',
+});
+const series = chart.addCandlestickSeries();
+series.setData(data); // Array of { time, open, high, low, close, volume }
+      `,
+    });
   },
 };
 
@@ -64,7 +80,20 @@ series.setData(data);`,
       wickDownColor: '#ff4081',
     });
     series.setData(AAPL_DAILY);
-    return container;
+    return withDocs(container, {
+      description:
+        'Customize candle colors by passing <code>upColor</code>, <code>downColor</code>, <code>wickUpColor</code>, and <code>wickDownColor</code> to <code>addCandlestickSeries()</code>. ' +
+        'You can also set <code>borderUpColor</code> and <code>borderDownColor</code> for the candle body border.',
+      code: `
+const series = chart.addCandlestickSeries({
+  upColor: '#00e5ff',       // Bullish candle body
+  downColor: '#ff4081',     // Bearish candle body
+  wickUpColor: '#00e5ff',   // Bullish wick color
+  wickDownColor: '#ff4081', // Bearish wick color
+});
+series.setData(data);
+      `,
+    });
   },
 };
 
@@ -83,7 +112,14 @@ series.setData(data.slice(0, 20)); // Only 20 bars`,
     const chart = createChart(container, { autoSize: true, symbol: 'AAPL' });
     const series = chart.addCandlestickSeries();
     series.setData(generateOHLCV(20));
-    return container;
+    return withDocs(container, {
+      description:
+        'The chart automatically adjusts its scale to fit any number of bars. Here only 20 bars are rendered, demonstrating that the chart handles small datasets gracefully.',
+      code: `
+const series = chart.addCandlestickSeries();
+series.setData(data.slice(0, 20)); // Only 20 bars
+      `,
+    });
   },
 };
 
@@ -107,6 +143,19 @@ series.setData(data);`,
     const chart = createChart(container, { autoSize: true, symbol: 'AAPL', lastPriceLine: { visible: false } });
     const series = chart.addCandlestickSeries();
     series.setData(AAPL_DAILY);
-    return container;
+    return withDocs(container, {
+      description:
+        'By default, a horizontal dashed line is drawn at the latest close price. ' +
+        'Disable it by setting <code>lastPriceLine: { visible: false }</code> in chart options.',
+      code: `
+const chart = createChart(container, {
+  autoSize: true,
+  symbol: 'AAPL',
+  lastPriceLine: { visible: false },
+});
+const series = chart.addCandlestickSeries();
+series.setData(data);
+      `,
+    });
   },
 };

--- a/stories/Customization/CustomFonts.stories.ts
+++ b/stories/Customization/CustomFonts.stories.ts
@@ -1,6 +1,7 @@
 import type { Meta, StoryObj } from '@storybook/html';
 import { createChart } from 'fin-charter';
 import { createChartContainer } from '../helpers';
+import { withDocs } from '../doc-renderer';
 import { AAPL_DAILY } from '../sample-data';
 
 const meta: Meta = {
@@ -49,7 +50,21 @@ const chart = createChart(container, {
     });
     const series = chart.addCandlestickSeries();
     series.setData(AAPL_DAILY);
-    return container;
+    return withDocs(container, {
+      description:
+        '<strong>Custom Fonts</strong> — Customize chart fonts via <code>layout: { fontFamily, fontSize }</code>. ' +
+        'Affects all text elements: price scale labels, time scale labels, legend, and tooltips.',
+      code: `import { createChart } from 'fin-charter';
+
+const chart = createChart(container, {
+  autoSize: true,
+  symbol: 'AAPL',
+  layout: {
+    fontFamily: '"Courier New", Courier, monospace',
+    fontSize: 11,
+  },
+});`,
+    });
   },
 };
 
@@ -81,7 +96,19 @@ export const SystemSansSerif: Story = {
     });
     const series = chart.addCandlestickSeries();
     series.setData(AAPL_DAILY);
-    return container;
+    return withDocs(container, {
+      description:
+        '<strong>System Sans-Serif</strong> — Uses the platform\'s native sans-serif font stack for a clean, ' +
+        'familiar appearance. Set via <code>layout: { fontFamily }</code>.',
+      code: `const chart = createChart(container, {
+  autoSize: true,
+  symbol: 'AAPL',
+  layout: {
+    fontFamily: '-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif',
+    fontSize: 12,
+  },
+});`,
+    });
   },
 };
 
@@ -110,6 +137,15 @@ export const LargeFontSize: Story = {
     });
     const series = chart.addCandlestickSeries();
     series.setData(AAPL_DAILY);
-    return container;
+    return withDocs(container, {
+      description:
+        '<strong>Large Font Size</strong> — Increase <code>layout.fontSize</code> for better readability on ' +
+        'large displays or high-density dashboards.',
+      code: `const chart = createChart(container, {
+  autoSize: true,
+  symbol: 'AAPL',
+  layout: { fontSize: 14 },
+});`,
+    });
   },
 };

--- a/stories/Customization/DualPriceScales.stories.ts
+++ b/stories/Customization/DualPriceScales.stories.ts
@@ -3,6 +3,7 @@ import { createChart } from 'fin-charter';
 import { computeSMA } from 'fin-charter/indicators';
 import type { Bar } from '../../src/core/types';
 import { createChartContainer } from '../helpers';
+import { withDocs } from '../doc-renderer';
 import { AAPL_DAILY } from '../sample-data';
 
 const meta: Meta = {
@@ -70,7 +71,26 @@ chart.addLineSeries({ color: '#f4c430', priceScaleId: 'left' });`,
     const smaSeries = chart.addLineSeries({ color: '#f4c430', lineWidth: 2, priceScaleId: 'left' });
     smaSeries.setData(indicatorToLineBars(AAPL_DAILY, smaValues));
 
-    return container;
+    return withDocs(container, {
+      description:
+        '<strong>Dual Price Scales</strong> — Enable both left and right price scales simultaneously. ' +
+        'Assign a series to a specific scale with <code>priceScaleId: \'left\'</code>. ' +
+        'Useful for overlaying instruments with different price ranges.',
+      code: `import { createChart } from 'fin-charter';
+
+const chart = createChart(container, {
+  autoSize: true,
+  symbol: 'AAPL',
+  rightPriceScale: { visible: true },
+  leftPriceScale: { visible: true },
+});
+
+// Candlesticks on right scale (default)
+chart.addCandlestickSeries();
+
+// SMA line on left scale
+chart.addLineSeries({ color: '#f4c430', priceScaleId: 'left' });`,
+    });
   },
 };
 
@@ -98,7 +118,17 @@ export const RightOnly: Story = {
     });
     const series = chart.addCandlestickSeries();
     series.setData(AAPL_DAILY);
-    return container;
+    return withDocs(container, {
+      description:
+        '<strong>Right Scale Only</strong> — The default configuration with only the right price scale visible. ' +
+        'Set <code>leftPriceScale: { visible: false }</code> to explicitly disable the left scale.',
+      code: `const chart = createChart(container, {
+  autoSize: true,
+  symbol: 'AAPL',
+  rightPriceScale: { visible: true },
+  leftPriceScale: { visible: false },
+});`,
+    });
   },
 };
 
@@ -126,6 +156,16 @@ export const LeftOnly: Story = {
     });
     const series = chart.addCandlestickSeries();
     series.setData(AAPL_DAILY);
-    return container;
+    return withDocs(container, {
+      description:
+        '<strong>Left Scale Only</strong> — Show only the left price scale by disabling the right. ' +
+        'Set <code>rightPriceScale: { visible: false }</code> and <code>leftPriceScale: { visible: true }</code>.',
+      code: `const chart = createChart(container, {
+  autoSize: true,
+  symbol: 'AAPL',
+  rightPriceScale: { visible: false },
+  leftPriceScale: { visible: true },
+});`,
+    });
   },
 };

--- a/stories/Customization/PriceFormatter.stories.ts
+++ b/stories/Customization/PriceFormatter.stories.ts
@@ -1,6 +1,7 @@
 import type { Meta, StoryObj } from '@storybook/html';
 import { createChart } from 'fin-charter';
 import { createChartContainer } from '../helpers';
+import { withDocs } from '../doc-renderer';
 import { AAPL_DAILY } from '../sample-data';
 
 const meta: Meta = {
@@ -43,7 +44,18 @@ const chart = createChart(container, {
     });
     const series = chart.addCandlestickSeries();
     series.setData(AAPL_DAILY);
-    return container;
+    return withDocs(container, {
+      description:
+        '<strong>Currency Format</strong> — Format prices as currency (<code>$XXX.XX</code>) using a custom ' +
+        '<code>priceFormatter</code> function passed to <code>createChart()</code>.',
+      code: `import { createChart } from 'fin-charter';
+
+const chart = createChart(container, {
+  autoSize: true,
+  symbol: 'AAPL',
+  priceFormatter: (price: number) => \`$\${price.toFixed(2)}\`,
+});`,
+    });
   },
 };
 
@@ -77,7 +89,20 @@ export const CompactFormat: Story = {
     });
     const series = chart.addCandlestickSeries();
     series.setData(AAPL_DAILY);
-    return container;
+    return withDocs(container, {
+      description:
+        '<strong>Compact Format</strong> — Shorten large numbers to human-readable abbreviations like ' +
+        '<code>1.5K</code> and <code>2.3M</code> using a custom <code>priceFormatter</code>.',
+      code: `const chart = createChart(container, {
+  autoSize: true,
+  symbol: 'AAPL',
+  priceFormatter: (price: number) => {
+    if (price >= 1_000_000) return \`\${(price / 1_000_000).toFixed(2)}M\`;
+    if (price >= 1_000) return \`\${(price / 1_000).toFixed(1)}K\`;
+    return price.toFixed(2);
+  },
+});`,
+    });
   },
 };
 
@@ -112,6 +137,15 @@ export const BasisPoints: Story = {
       close: b.close / base,
     }));
     series.setData(normalized);
-    return container;
+    return withDocs(container, {
+      description:
+        '<strong>Basis Points</strong> — Convert prices to basis points by multiplying by 100. ' +
+        'Useful for displaying yields, spreads, or normalized values with a <code>priceFormatter</code>.',
+      code: `const chart = createChart(container, {
+  autoSize: true,
+  symbol: 'AAPL',
+  priceFormatter: (price: number) => \`\${(price * 100).toFixed(0)} bps\`,
+});`,
+    });
   },
 };

--- a/stories/Customization/Themes.stories.ts
+++ b/stories/Customization/Themes.stories.ts
@@ -1,6 +1,7 @@
 import type { Meta, StoryObj } from '@storybook/html';
 import { createChart, DARK_THEME, LIGHT_THEME, COLORFUL_THEME } from 'fin-charter';
 import { createChartContainer } from '../helpers';
+import { withDocs } from '../doc-renderer';
 import { AAPL_DAILY } from '../sample-data';
 
 const meta: Meta = {
@@ -37,7 +38,15 @@ chart.applyOptions(DARK_THEME);`,
     chart.applyOptions(DARK_THEME);
     const series = chart.addCandlestickSeries();
     series.setData(AAPL_DAILY);
-    return container;
+    return withDocs(container, {
+      description:
+        '<strong>Dark Theme</strong> — Built-in dark theme with dark backgrounds and contrasting candle colors. ' +
+        'Apply with <code>chart.applyOptions(DARK_THEME)</code> or pass <code>theme: \'dark\'</code> to <code>createChart()</code>.',
+      code: `import { createChart, DARK_THEME } from 'fin-charter';
+
+const chart = createChart(container, { autoSize: true, symbol: 'AAPL', theme: 'dark' });
+chart.applyOptions(DARK_THEME);`,
+    });
   },
 };
 
@@ -66,7 +75,15 @@ chart.addCandlestickSeries({
       wickDownColor: '#F7525F',
     });
     series.setData(AAPL_DAILY);
-    return container;
+    return withDocs(container, {
+      description:
+        '<strong>Light Theme</strong> — Light theme with white backgrounds and clean styling. ' +
+        'Apply with <code>chart.applyOptions(LIGHT_THEME)</code> or pass <code>theme: \'light\'</code> to <code>createChart()</code>.',
+      code: `import { createChart, LIGHT_THEME } from 'fin-charter';
+
+const chart = createChart(container, { autoSize: true, symbol: 'AAPL', theme: 'light' });
+chart.applyOptions(LIGHT_THEME);`,
+    });
   },
 };
 
@@ -95,6 +112,14 @@ chart.addCandlestickSeries({
       wickDownColor: '#ff4a68',
     });
     series.setData(AAPL_DAILY);
-    return container;
+    return withDocs(container, {
+      description:
+        '<strong>Colorful Theme</strong> — Vibrant colorful theme ideal for dashboards. ' +
+        'Apply with <code>chart.applyOptions(COLORFUL_THEME)</code> or pass <code>theme: \'colorful\'</code> to <code>createChart()</code>.',
+      code: `import { createChart, COLORFUL_THEME } from 'fin-charter';
+
+const chart = createChart(container, { autoSize: true, symbol: 'AAPL', theme: 'colorful' });
+chart.applyOptions(COLORFUL_THEME);`,
+    });
   },
 };

--- a/stories/Drawings/NewDrawings.stories.ts
+++ b/stories/Drawings/NewDrawings.stories.ts
@@ -1,6 +1,7 @@
 import type { Meta, StoryObj } from '@storybook/html';
 import { createChart } from 'fin-charter';
 import { generateOHLCV, createChartContainer } from '../helpers';
+import { withDocs } from '../doc-renderer';
 
 const meta: Meta = {
   title: 'Drawings/New Drawing Tools',
@@ -47,7 +48,15 @@ chart.addDrawing('ray', [
       ],
       { color: '#2196F3', lineWidth: 2 },
     );
-    return container;
+    return withDocs(container, {
+      description:
+        '<strong>Ray</strong> draws a line that starts at the first point and extends infinitely through the second point. ' +
+        'Use rays to project <code>support</code> and <code>resistance</code> levels into the future.',
+      code: `chart.addDrawing('ray', [
+  { time: data[20].time, price: data[20].close },
+  { time: data[60].time, price: data[60].close },
+], { color: '#2196F3', lineWidth: 2 });`,
+    });
   },
 };
 
@@ -81,7 +90,15 @@ chart.addDrawing('arrow', [
       ],
       { color: '#FF9800', lineWidth: 2 },
     );
-    return container;
+    return withDocs(container, {
+      description:
+        '<strong>Arrow</strong> draws a directional line with an arrowhead at the endpoint. ' +
+        'Useful for annotating <code>trend direction</code> or highlighting specific price moves on the chart.',
+      code: `chart.addDrawing('arrow', [
+  { time: data[20].time, price: data[20].close },
+  { time: data[60].time, price: data[60].close },
+], { color: '#FF9800', lineWidth: 2 });`,
+    });
   },
 };
 
@@ -117,7 +134,16 @@ chart.addDrawing('channel', [
       ],
       { color: '#9C27B0', fillColor: 'rgba(156, 39, 176, 0.1)', lineWidth: 1 },
     );
-    return container;
+    return withDocs(container, {
+      description:
+        '<strong>Channel</strong> draws two parallel trend lines defined by three anchor points. ' +
+        'Channels help identify <code>price consolidation zones</code> and potential breakout areas in technical analysis.',
+      code: `chart.addDrawing('channel', [
+  { time: data[20].time, price: data[20].low },
+  { time: data[60].time, price: data[60].high },
+  { time: data[40].time, price: data[40].low },
+], { color: '#9C27B0', fillColor: 'rgba(156, 39, 176, 0.1)', lineWidth: 1 });`,
+    });
   },
 };
 
@@ -151,7 +177,15 @@ chart.addDrawing('ellipse', [
       ],
       { color: '#E91E63', fillColor: 'rgba(233, 30, 99, 0.1)', lineWidth: 1 },
     );
-    return container;
+    return withDocs(container, {
+      description:
+        '<strong>Ellipse</strong> draws an oval shape between two anchor points. ' +
+        'Use it to circle <code>chart patterns</code> like double tops, cup-and-handle formations, or areas of interest.',
+      code: `chart.addDrawing('ellipse', [
+  { time: data[20].time, price: data[20].low },
+  { time: data[60].time, price: data[60].high },
+], { color: '#E91E63', fillColor: 'rgba(233, 30, 99, 0.1)', lineWidth: 1 });`,
+    });
   },
 };
 
@@ -187,7 +221,16 @@ chart.addDrawing('pitchfork', [
       ],
       { color: '#00BCD4', lineWidth: 1 },
     );
-    return container;
+    return withDocs(container, {
+      description:
+        '<strong>Pitchfork</strong> (Andrews\' Pitchfork) uses three points to define a median line and two parallel channel boundaries. ' +
+        'It identifies potential <code>support</code>, <code>resistance</code>, and <code>median reversion</code> levels.',
+      code: `chart.addDrawing('pitchfork', [
+  { time: data[20].time, price: data[20].low },
+  { time: data[40].time, price: data[40].high },
+  { time: data[60].time, price: data[60].low },
+], { color: '#00BCD4', lineWidth: 1 });`,
+    });
   },
 };
 
@@ -223,7 +266,16 @@ chart.addDrawing('fib-projection', [
       ],
       { color: '#FF9800', lineWidth: 1 },
     );
-    return container;
+    return withDocs(container, {
+      description:
+        '<strong>Fibonacci Projection</strong> uses three points (swing low, swing high, pullback) to project ' +
+        'potential <code>price targets</code> based on Fibonacci ratios like 1.618 and 2.618.',
+      code: `chart.addDrawing('fib-projection', [
+  { time: data[20].time, price: data[20].low },
+  { time: data[40].time, price: data[40].high },
+  { time: data[60].time, price: data[60].close },
+], { color: '#FF9800', lineWidth: 1 });`,
+    });
   },
 };
 
@@ -257,7 +309,15 @@ chart.addDrawing('fib-arc', [
       ],
       { color: '#4CAF50', lineWidth: 1 },
     );
-    return container;
+    return withDocs(container, {
+      description:
+        '<strong>Fibonacci Arc</strong> draws curved lines at key Fibonacci levels (38.2%, 50%, 61.8%) radiating from ' +
+        'the second anchor point. Arcs combine <code>price</code> and <code>time</code> dimensions for retracement analysis.',
+      code: `chart.addDrawing('fib-arc', [
+  { time: data[20].time, price: data[20].low },
+  { time: data[60].time, price: data[60].high },
+], { color: '#4CAF50', lineWidth: 1 });`,
+    });
   },
 };
 
@@ -291,7 +351,15 @@ chart.addDrawing('fib-fan', [
       ],
       { color: '#FF5722', lineWidth: 1 },
     );
-    return container;
+    return withDocs(container, {
+      description:
+        '<strong>Fibonacci Fan</strong> draws diagonal lines from the first anchor through Fibonacci retracement levels ' +
+        'of the second anchor. The fan lines act as dynamic <code>support</code> and <code>resistance</code> over time.',
+      code: `chart.addDrawing('fib-fan', [
+  { time: data[20].time, price: data[20].low },
+  { time: data[60].time, price: data[60].high },
+], { color: '#FF5722', lineWidth: 1 });`,
+    });
   },
 };
 
@@ -321,7 +389,14 @@ chart.addDrawing('crossline', [
       [{ time: data[50].time, price: data[50].close }],
       { color: '#607D8B', lineWidth: 1 },
     );
-    return container;
+    return withDocs(container, {
+      description:
+        '<strong>Crossline</strong> places a full-width horizontal and vertical line intersecting at a single point. ' +
+        'Ideal for marking a specific <code>price</code> and <code>time</code> coordinate on the chart.',
+      code: `chart.addDrawing('crossline', [
+  { time: data[50].time, price: data[50].close },
+], { color: '#607D8B', lineWidth: 1 });`,
+    });
   },
 };
 
@@ -355,6 +430,14 @@ chart.addDrawing('measurement', [
       ],
       { color: '#795548', lineWidth: 1 },
     );
-    return container;
+    return withDocs(container, {
+      description:
+        '<strong>Measurement</strong> draws a rectangle between two points and displays the <code>price change</code>, ' +
+        '<code>percentage change</code>, and <code>bar count</code> within the selected range.',
+      code: `chart.addDrawing('measurement', [
+  { time: data[20].time, price: data[20].low },
+  { time: data[60].time, price: data[60].high },
+], { color: '#795548', lineWidth: 1 });`,
+    });
   },
 };

--- a/stories/Features/ChartState.stories.ts
+++ b/stories/Features/ChartState.stories.ts
@@ -3,6 +3,7 @@ import { createChart } from 'fin-charter';
 import type { Bar } from '../../src/core/types';
 import { createChartContainer } from '../helpers';
 import { AAPL_DAILY } from '../sample-data';
+import { withDocs } from '../doc-renderer';
 
 const meta: Meta = {
   title: 'Features/Chart State',
@@ -117,6 +118,27 @@ await chart.importState(JSON.parse(json), async (seriesId) => {
     wrapper.appendChild(toolbar);
     wrapper.appendChild(container);
     wrapper.appendChild(pre);
-    return wrapper;
+    return withDocs(wrapper, {
+      description:
+        '<strong>Save and restore</strong> the full chart state including layout, series configuration, and indicators. ' +
+        'Use <code>chart.exportState()</code> to serialize the current state to JSON, and ' +
+        '<code>chart.importState()</code> to restore it. Bar data is reloaded via a <code>dataLoader</code> callback.',
+      code: `
+import { createChart } from 'fin-charter';
+
+const chart = createChart(container, { autoSize: true, symbol: 'AAPL' });
+const series = chart.addCandlestickSeries();
+series.setData(data);
+
+// Save state
+const state = chart.exportState();
+const json = JSON.stringify(state);
+
+// Restore state (dataLoader fetches bar data for each series)
+await chart.importState(JSON.parse(json), async (seriesId) => {
+  return await fetchData(seriesId);
+});
+      `,
+    });
   },
 };

--- a/stories/Features/ComparisonMode.stories.ts
+++ b/stories/Features/ComparisonMode.stories.ts
@@ -3,6 +3,7 @@ import { createChart } from 'fin-charter';
 import type { ISeriesApi } from 'fin-charter';
 import { createChartContainer, generateOHLCV } from '../helpers';
 import { AAPL_DAILY } from '../sample-data';
+import { withDocs } from '../doc-renderer';
 
 const meta: Meta = {
   title: 'Features/Comparison Mode',
@@ -122,6 +123,24 @@ compSeries.setData(msftData);`,
 
     wrapper.appendChild(toolbar);
     wrapper.appendChild(container);
-    return wrapper;
+    return withDocs(wrapper, {
+      description:
+        'Compare <strong>multiple symbols</strong> on the same chart with a <strong>percentage change</strong> Y-axis. ' +
+        'Enable comparison mode with <code>chart.setComparisonMode(true)</code>, then add comparison series ' +
+        'using <code>chart.addLineSeries()</code>. The Y-axis automatically switches to show relative performance.',
+      code: `
+import { createChart } from 'fin-charter';
+
+const chart = createChart(container, { autoSize: true, symbol: 'AAPL' });
+const mainSeries = chart.addCandlestickSeries();
+mainSeries.setData(aaplData);
+
+// Enable comparison mode (Y-axis shows % change)
+chart.setComparisonMode(true);
+
+const compSeries = chart.addLineSeries({ color: '#2196F3' });
+compSeries.setData(msftData);
+      `,
+    });
   },
 };

--- a/stories/Features/ContextMenu.stories.ts
+++ b/stories/Features/ContextMenu.stories.ts
@@ -1,6 +1,7 @@
 import type { Meta, StoryObj } from '@storybook/html';
 import { createChart } from 'fin-charter';
 import { generateOHLCV, createChartContainer } from '../helpers';
+import { withDocs } from '../doc-renderer';
 
 const meta: Meta = {
   title: 'Features/Context Menu',
@@ -99,6 +100,30 @@ chart.addIndicator('rsi', {
       label: 'RSI 14',
     });
 
-    return container;
+    return withDocs(container, {
+      description:
+        '<strong>Context-sensitive right-click menus</strong> adapt to what you click on. ' +
+        'Right-click a <strong>drawing</strong> for Edit, Duplicate, Remove, Bring to Front, and Send to Back. ' +
+        'Right-click on the <strong>chart area</strong> for Reset Zoom and Scroll to Latest. ' +
+        'Right-click an <strong>indicator pane</strong> header for Settings, Hide, and Remove.',
+      code: `
+import { createChart } from 'fin-charter';
+
+const chart = createChart(container, { autoSize: true, symbol: 'AAPL' });
+const series = chart.addCandlestickSeries();
+series.setData(data);
+
+// Add a drawing — right-click it to see the context menu
+chart.addDrawing('trendline', [
+  { time: data[20].time, price: data[20].close },
+  { time: data[60].time, price: data[60].close },
+], { color: '#2196F3', lineWidth: 2 });
+
+// Add an indicator pane — right-click the header for options
+chart.addIndicator('rsi', {
+  source: series, params: { period: 14 }, color: '#ab47bc', label: 'RSI 14',
+});
+      `,
+    });
   },
 };

--- a/stories/Features/DataChanged.stories.ts
+++ b/stories/Features/DataChanged.stories.ts
@@ -3,6 +3,7 @@ import { createChart } from 'fin-charter';
 import type { Bar } from '../../src/core/types';
 import { createChartContainer } from '../helpers';
 import { AAPL_DAILY } from '../sample-data';
+import { withDocs } from '../doc-renderer';
 
 const meta: Meta = {
   title: 'Features/Data Changed',
@@ -93,6 +94,25 @@ series.update({ time, open, high, low, close, volume });`,
     wrapper.appendChild(counter);
     wrapper.appendChild(container);
 
-    return wrapper;
+    return withDocs(wrapper, {
+      description:
+        'Subscribe to <strong>data change events</strong> with <code>series.subscribeDataChanged()</code>. ' +
+        'The callback fires each time data is updated via <code>series.update()</code> or <code>series.setData()</code>. ' +
+        'This demo simulates real-time bar updates every second and counts the events.',
+      code: `
+import { createChart } from 'fin-charter';
+
+const chart = createChart(container, { autoSize: true, symbol: 'AAPL' });
+const series = chart.addCandlestickSeries();
+series.setData(data);
+
+series.subscribeDataChanged(() => {
+  console.log('Data updated');
+});
+
+// Trigger an update
+series.update({ time, open, high, low, close, volume });
+      `,
+    });
   },
 };

--- a/stories/Features/DrawingTools.stories.ts
+++ b/stories/Features/DrawingTools.stories.ts
@@ -1,6 +1,7 @@
 import type { Meta, StoryObj } from '@storybook/html';
 import { createChart } from 'fin-charter';
 import { createChartContainer } from '../helpers';
+import { withDocs } from '../doc-renderer';
 import { AAPL_DAILY } from '../sample-data';
 
 const meta: Meta = {
@@ -93,7 +94,19 @@ chart.setActiveDrawingTool(null);`,
     toolbar.appendChild(status);
     wrapper.appendChild(toolbar);
     wrapper.appendChild(container);
-    return wrapper;
+
+    const description = '<strong>Drawing tools</strong> allow users to annotate charts interactively. Call <code>chart.setActiveDrawingTool(type)</code> to activate a tool, then click on the chart to place the drawing. Pass <code>null</code> to deactivate. Supported types: <code>horizontal-line</code>, <code>trendline</code>, <code>fibonacci</code>, <code>rectangle</code>, and more.';
+    const code = `const chart = createChart(container, { autoSize: true, symbol: 'AAPL' });
+const series = chart.addCandlestickSeries();
+series.setData(data);
+
+// Activate a drawing tool (user clicks chart to place it)
+chart.setActiveDrawingTool('trendline');
+
+// Cancel the active tool
+chart.setActiveDrawingTool(null);`;
+
+    return withDocs(wrapper, { description, code });
   },
 };
 
@@ -157,6 +170,27 @@ chart.addDrawing('trendline',
       { color: '#ef9a9a', lineWidth: 1 },
     );
 
-    return container;
+    const description = 'Add drawings <strong>programmatically</strong> with <code>chart.addDrawing(type, points, options)</code>. Each drawing type takes an array of anchor points (with <code>time</code> and <code>price</code> fields) and optional styling. This is useful for pre-populating charts with saved analysis.';
+    const code = `chart.addDrawing('horizontal-line',
+  [{ time: t1, price: 190 }],
+  { color: '#f4c430', lineWidth: 1, lineDash: [4, 4] },
+);
+
+chart.addDrawing('trendline',
+  [{ time: t1, price: low1 }, { time: t2, price: high2 }],
+  { color: '#22AB94', lineWidth: 2 },
+);
+
+chart.addDrawing('rectangle',
+  [{ time: t1, price: low1 }, { time: t2, price: high2 }],
+  { color: 'rgba(33, 150, 243, 0.3)', lineWidth: 1 },
+);
+
+chart.addDrawing('fibonacci',
+  [{ time: t1, price: swingLow }, { time: t2, price: swingHigh }],
+  { color: '#ef9a9a', lineWidth: 1 },
+);`;
+
+    return withDocs(container, { description, code });
   },
 };

--- a/stories/Features/EventMarkers.stories.ts
+++ b/stories/Features/EventMarkers.stories.ts
@@ -2,6 +2,7 @@ import type { Meta, StoryObj } from '@storybook/html';
 import { createChart } from 'fin-charter';
 import type { ChartEvent } from 'fin-charter';
 import { createChartContainer } from '../helpers';
+import { withDocs } from '../doc-renderer';
 import { AAPL_DAILY } from '../sample-data';
 
 const meta: Meta = {
@@ -134,6 +135,25 @@ series.setEvents([
 
     series.setEvents(events);
 
-    return container;
+    const description = '<strong>Event markers</strong> display corporate events such as dividends, earnings, and stock splits directly on the chart. Call <code>series.setEvents(array)</code> with objects specifying <code>eventType</code> (<code>dividend</code>, <code>earnings</code>, <code>split</code>), <code>title</code>, <code>description</code>, and <code>value</code>. Events appear as shaped markers with tooltips showing details on hover.';
+    const code = `series.setEvents([
+  {
+    time: dividendDate, position: 'belowBar', shape: 'arrowUp',
+    color: '#4caf50', text: 'D', eventType: 'dividend',
+    title: 'Quarterly Dividend', value: '$0.24/share',
+  },
+  {
+    time: earningsDate, position: 'aboveBar', shape: 'arrowDown',
+    color: '#F7525F', text: 'E', eventType: 'earnings',
+    title: 'Q1 Earnings', value: 'Beat estimates',
+  },
+  {
+    time: splitDate, position: 'aboveBar', shape: 'square',
+    color: '#ff9800', text: 'S', eventType: 'split',
+    title: 'Stock Split', value: '4:1',
+  },
+]);`;
+
+    return withDocs(container, { description, code });
   },
 };

--- a/stories/Features/ExtendedHours.stories.ts
+++ b/stories/Features/ExtendedHours.stories.ts
@@ -2,6 +2,7 @@ import type { Meta, StoryObj } from '@storybook/html';
 import { createChart, US_EQUITY_SESSIONS } from 'fin-charter';
 import type { Bar } from '../../src/core/types';
 import { createChartContainer } from '../helpers';
+import { withDocs } from '../doc-renderer';
 
 const meta: Meta = {
   title: 'Features/Extended Hours',
@@ -131,6 +132,24 @@ chart.setSessionFilter('regular');`,
 
     wrapper.appendChild(toolbar);
     wrapper.appendChild(container);
-    return wrapper;
+    return withDocs(wrapper, {
+      description:
+        'Display <strong>pre-market</strong> and <strong>post-market</strong> trading sessions alongside regular hours. ' +
+        'Use <code>chart.setMarketSessions()</code> to define session boundaries and ' +
+        '<code>chart.setSessionFilter()</code> to toggle between <code>"regular"</code>, <code>"extended"</code>, or <code>"all"</code> sessions.',
+      code: `
+import { createChart, US_EQUITY_SESSIONS } from 'fin-charter';
+
+const chart = createChart(container, { autoSize: true, symbol: 'AAPL' });
+chart.setMarketSessions(US_EQUITY_SESSIONS);
+chart.setPeriodicity({ interval: 5, unit: 'minute' });
+
+const series = chart.addCandlestickSeries();
+series.setData(intradayData);
+
+// Filter to regular hours only
+chart.setSessionFilter('regular');
+      `,
+    });
   },
 };

--- a/stories/Features/FitContent.stories.ts
+++ b/stories/Features/FitContent.stories.ts
@@ -2,6 +2,7 @@ import type { Meta, StoryObj } from '@storybook/html';
 import { createChart } from 'fin-charter';
 import { createChartContainer } from '../helpers';
 import { AAPL_DAILY } from '../sample-data';
+import { withDocs } from '../doc-renderer';
 
 const meta: Meta = {
   title: 'Features/Fit Content',
@@ -67,6 +68,25 @@ chart.fitContent();`,
     wrapper.appendChild(button);
     wrapper.appendChild(container);
 
-    return wrapper;
+    return withDocs(wrapper, {
+      description:
+        'Auto-fit all data to the visible area with <code>chart.fitContent()</code>. ' +
+        'The chart starts with a narrow <code>barSpacing: 2</code> so bars are compressed. ' +
+        'Click the <strong>Fit Content</strong> button to auto-scale so all bars fill the visible width.',
+      code: `
+import { createChart } from 'fin-charter';
+
+const chart = createChart(container, {
+  autoSize: true,
+  symbol: 'AAPL',
+  timeScale: { barSpacing: 2 },
+});
+const series = chart.addCandlestickSeries();
+series.setData(data);
+
+// Auto-scale to fit all bars in the visible area
+chart.fitContent();
+      `,
+    });
   },
 };

--- a/stories/Features/HUD.stories.ts
+++ b/stories/Features/HUD.stories.ts
@@ -1,6 +1,7 @@
 import type { Meta, StoryObj } from '@storybook/html';
 import { createChart } from 'fin-charter';
 import { createChartContainer } from '../helpers';
+import { withDocs } from '../doc-renderer';
 import { AAPL_DAILY } from '../sample-data';
 
 const meta: Meta = {
@@ -81,6 +82,45 @@ chart.addIndicator('rsi', {
       label: 'MACD',
     });
 
-    return container;
+    const description = 'The <strong>HUD (Heads-Up Display)</strong> shows real-time OHLC values, series labels, and indicator values as the crosshair moves over the chart. Each indicator (overlay or separate pane) automatically adds a row to the HUD. Hover over the chart to see live values update.';
+    const code = `const chart = createChart(container, { autoSize: true, symbol: 'AAPL' });
+const candleSeries = chart.addCandlestickSeries({ label: 'AAPL' });
+candleSeries.setData(data);
+
+// SMA 20 overlay
+chart.addIndicator('sma', {
+  source: candleSeries,
+  params: { period: 20 },
+  color: '#f4c430',
+  lineWidth: 2,
+  label: 'SMA 20',
+});
+
+// EMA 50 overlay
+chart.addIndicator('ema', {
+  source: candleSeries,
+  params: { period: 50 },
+  color: '#00e5ff',
+  lineWidth: 2,
+  label: 'EMA 50',
+});
+
+// RSI pane
+chart.addIndicator('rsi', {
+  source: candleSeries,
+  params: { period: 14 },
+  color: '#ab47bc',
+  label: 'RSI',
+});
+
+// MACD pane
+chart.addIndicator('macd', {
+  source: candleSeries,
+  params: { fastPeriod: 12, slowPeriod: 26, signalPeriod: 9 },
+  color: '#ff6b6b',
+  label: 'MACD',
+});`;
+
+    return withDocs(container, { description, code });
   },
 };

--- a/stories/Features/HeikinAshi.stories.ts
+++ b/stories/Features/HeikinAshi.stories.ts
@@ -2,6 +2,7 @@ import type { Meta, StoryObj } from '@storybook/html';
 import { createChart } from 'fin-charter';
 import { createChartContainer } from '../helpers';
 import { AAPL_DAILY } from '../sample-data';
+import { withDocs } from '../doc-renderer';
 
 const meta: Meta = {
   title: 'Features/Heikin-Ashi',
@@ -51,6 +52,21 @@ series.setData(data);`,
 
     series.setData(AAPL_DAILY);
 
-    return container;
+    return withDocs(container, {
+      description:
+        '<strong>Heikin-Ashi</strong> candlesticks smooth price action by averaging open and close values, ' +
+        'making trends easier to identify. Use <code>chart.addHeikinAshiSeries()</code> to render ' +
+        'Heikin-Ashi candles computed from standard OHLCV data.',
+      code: `
+import { createChart } from 'fin-charter';
+
+const chart = createChart(container, { autoSize: true, symbol: 'AAPL' });
+const series = chart.addHeikinAshiSeries({
+  upColor: '#22AB94',
+  downColor: '#F7525F',
+});
+series.setData(data);
+      `,
+    });
   },
 };

--- a/stories/Features/HudCollapse.stories.ts
+++ b/stories/Features/HudCollapse.stories.ts
@@ -1,6 +1,7 @@
 import type { Meta, StoryObj } from '@storybook/html';
 import { createChart } from 'fin-charter';
 import { generateOHLCV, createChartContainer } from '../helpers';
+import { withDocs } from '../doc-renderer';
 
 const meta: Meta = {
   title: 'Features/HUD Collapse',
@@ -99,6 +100,28 @@ chart.addIndicator('mfi', { source: series, params: { period: 14 }, color: '#E91
       label: 'MFI 14',
     });
 
-    return container;
+    return withDocs(container, {
+      description:
+        '<strong>Collapse or expand</strong> the HUD indicator rows to save screen space. ' +
+        'Click the <strong>chevron (^)</strong> in the top-right corner of the HUD to collapse all indicator rows at once. ' +
+        'Individual rows can be toggled independently via the <strong>visibility eye icon</strong> in the HUD.',
+      code: `
+import { createChart } from 'fin-charter';
+
+const chart = createChart(container, { autoSize: true, symbol: 'AAPL' });
+const series = chart.addCandlestickSeries();
+series.setData(data);
+
+// Overlay indicators appear in the main HUD row
+chart.addIndicator('sma', {
+  source: series, params: { period: 20 }, color: '#f4c430', label: 'SMA 20',
+});
+
+// Separate-pane indicators get their own collapsible HUD row
+chart.addIndicator('rsi', {
+  source: series, params: { period: 14 }, color: '#ab47bc', label: 'RSI 14',
+});
+      `,
+    });
   },
 };

--- a/stories/Features/IndicatorPanes.stories.ts
+++ b/stories/Features/IndicatorPanes.stories.ts
@@ -2,6 +2,7 @@ import type { Meta, StoryObj } from '@storybook/html';
 import { createChart } from 'fin-charter';
 import { createChartContainer } from '../helpers';
 import { AAPL_DAILY } from '../sample-data';
+import { withDocs } from '../doc-renderer';
 
 const meta: Meta = {
   title: 'Features/Indicator Panes',
@@ -72,7 +73,34 @@ chart.addIndicator('macd', {
       label: 'MACD',
     });
 
-    return container;
+    return withDocs(container, {
+      description:
+        'Add <strong>indicators</strong> in separate panes below the main chart or as overlays using ' +
+        '<code>chart.addIndicator()</code>. Overlays like <strong>SMA</strong> render on the price pane, while ' +
+        'oscillators like <strong>RSI</strong> and <strong>MACD</strong> get their own dedicated panes.',
+      code: `
+import { createChart } from 'fin-charter';
+
+const chart = createChart(container, { autoSize: true, symbol: 'AAPL' });
+const series = chart.addCandlestickSeries();
+series.setData(data);
+
+// Overlay indicator on the price pane
+chart.addIndicator('sma', {
+  source: series, params: { period: 20 }, color: '#f4c430', label: 'SMA 20',
+});
+
+// Separate-pane indicators
+chart.addIndicator('rsi', {
+  source: series, params: { period: 14 }, color: '#00e5ff', label: 'RSI 14',
+});
+chart.addIndicator('macd', {
+  source: series,
+  params: { fastPeriod: 12, slowPeriod: 26, signalPeriod: 9 },
+  color: '#ff6b6b', label: 'MACD',
+});
+      `,
+    });
   },
 };
 
@@ -149,6 +177,22 @@ chart.addIndicator('adx', { source: series, params: { period: 14 }, label: 'ADX'
       label: 'ADX 14',
     });
 
-    return container;
+    return withDocs(container, {
+      description:
+        'A comprehensive example showing <strong>all supported indicator types</strong>: overlays like ' +
+        '<code>VWAP</code> and <code>Bollinger Bands</code> on the price pane, plus oscillators like ' +
+        '<code>RSI</code>, <code>Stochastic</code>, <code>ATR</code>, and <code>ADX</code> in separate panes.',
+      code: `
+chart.addIndicator('vwap', { source: series, color: '#ff9800', label: 'VWAP' });
+chart.addIndicator('bollinger', {
+  source: series, params: { period: 20, stdDev: 2 }, label: 'BB 20,2',
+});
+chart.addIndicator('stochastic', {
+  source: series, params: { kPeriod: 14, dPeriod: 3 }, label: 'Stoch',
+});
+chart.addIndicator('atr', { source: series, params: { period: 14 }, label: 'ATR' });
+chart.addIndicator('adx', { source: series, params: { period: 14 }, label: 'ADX' });
+      `,
+    });
   },
 };

--- a/stories/Features/LastPriceLine.stories.ts
+++ b/stories/Features/LastPriceLine.stories.ts
@@ -1,6 +1,7 @@
 import type { Meta, StoryObj } from '@storybook/html';
 import { createChart } from 'fin-charter';
 import { createChartContainer } from '../helpers';
+import { withDocs } from '../doc-renderer';
 import { AAPL_DAILY } from '../sample-data';
 
 const meta: Meta = {
@@ -46,7 +47,17 @@ series.setData(data);`,
     });
     const series = chart.addCandlestickSeries();
     series.setData(AAPL_DAILY);
-    return container;
+
+    const description = 'The <strong>last price line</strong> is a horizontal dashed line anchored to the most recent close price. It helps traders quickly see where the current price sits on the chart. Enable it with <code>lastPriceLine: { visible: true }</code>.';
+    const code = `const chart = createChart(container, {
+  autoSize: true,
+  symbol: 'AAPL',
+  lastPriceLine: { visible: true },
+});
+const series = chart.addCandlestickSeries();
+series.setData(data);`;
+
+    return withDocs(container, { description, code });
   },
 };
 
@@ -72,7 +83,15 @@ export const Hidden: Story = {
     });
     const series = chart.addCandlestickSeries();
     series.setData(AAPL_DAILY);
-    return container;
+
+    const description = 'Hide the last price line by setting <code>lastPriceLine: { visible: false }</code>. This gives a cleaner chart when the current price indicator is not needed.';
+    const code = `const chart = createChart(container, {
+  autoSize: true,
+  symbol: 'AAPL',
+  lastPriceLine: { visible: false },
+});`;
+
+    return withDocs(container, { description, code });
   },
 };
 
@@ -100,6 +119,16 @@ series.setData(data);`,
     });
     const series = chart.addLineSeries({ color: '#00e5ff', lineWidth: 2 });
     series.setData(AAPL_DAILY);
-    return container;
+
+    const description = 'The <strong>last price line</strong> works with any series type, including line series. The dashed line matches the series color and tracks the final data point.';
+    const code = `const chart = createChart(container, {
+  autoSize: true,
+  symbol: 'AAPL',
+  lastPriceLine: { visible: true },
+});
+const series = chart.addLineSeries({ color: '#00e5ff' });
+series.setData(data);`;
+
+    return withDocs(container, { description, code });
   },
 };

--- a/stories/Features/OHLCLegend.stories.ts
+++ b/stories/Features/OHLCLegend.stories.ts
@@ -1,6 +1,7 @@
 import type { Meta, StoryObj } from '@storybook/html';
 import { createChart } from 'fin-charter';
 import { createChartContainer } from '../helpers';
+import { withDocs } from '../doc-renderer';
 import { AAPL_DAILY } from '../sample-data';
 
 const meta: Meta = {
@@ -46,7 +47,17 @@ series.setData(data);`,
     });
     const series = chart.addCandlestickSeries();
     series.setData(AAPL_DAILY);
-    return container;
+
+    const description = 'The <strong>OHLC legend</strong> and <strong>tooltip</strong> update live as you move the crosshair over the chart. The legend shows Open/High/Low/Close values in the top-left corner, while the tooltip follows the cursor as a floating panel. Enable the tooltip with <code>tooltip: { enabled: true }</code> in chart options.';
+    const code = `const chart = createChart(container, {
+  autoSize: true,
+  symbol: 'AAPL',
+  tooltip: { enabled: true },
+});
+const series = chart.addCandlestickSeries();
+series.setData(data);`;
+
+    return withDocs(container, { description, code });
   },
 };
 
@@ -72,7 +83,15 @@ export const TooltipDisabled: Story = {
     });
     const series = chart.addCandlestickSeries();
     series.setData(AAPL_DAILY);
-    return container;
+
+    const description = 'Disable the floating tooltip with <code>tooltip: { enabled: false }</code>. The <strong>OHLC legend</strong> in the top-left corner still updates as you hover, providing a cleaner look when the tooltip panel is not needed.';
+    const code = `const chart = createChart(container, {
+  autoSize: true,
+  symbol: 'AAPL',
+  tooltip: { enabled: false },
+});`;
+
+    return withDocs(container, { description, code });
   },
 };
 
@@ -100,6 +119,15 @@ export const WithVolume: Story = {
     });
     const series = chart.addCandlestickSeries();
     series.setData(AAPL_DAILY);
-    return container;
+
+    const description = 'Combine the <strong>OHLC legend</strong> with a <strong>volume overlay</strong> for a complete data view. The legend and tooltip include volume information when <code>volume: { visible: true }</code> is set alongside the tooltip.';
+    const code = `const chart = createChart(container, {
+  autoSize: true,
+  symbol: 'AAPL',
+  tooltip: { enabled: true },
+  volume: { visible: true },
+});`;
+
+    return withDocs(container, { description, code });
   },
 };

--- a/stories/Features/Pagination.stories.ts
+++ b/stories/Features/Pagination.stories.ts
@@ -2,6 +2,7 @@ import type { Meta, StoryObj } from '@storybook/html';
 import { createChart } from 'fin-charter';
 import type { Bar } from '../../src/core/types';
 import { createChartContainer, generateOHLCV } from '../helpers';
+import { withDocs } from '../doc-renderer';
 
 const meta: Meta = {
   title: 'Features/Pagination',
@@ -92,6 +93,26 @@ chart.subscribeVisibleRangeChange(async (range) => {
 
     wrapper.appendChild(statusBar);
     wrapper.appendChild(container);
-    return wrapper;
+    return withDocs(wrapper, {
+      description:
+        '<strong>Infinite scroll-back</strong> loads older data as the user pans left. ' +
+        'Use <code>chart.subscribeVisibleRangeChange()</code> to detect when the visible range approaches the first bar, ' +
+        'then call <code>series.prependData()</code> to prepend historical bars without replacing existing data.',
+      code: `
+import { createChart } from 'fin-charter';
+
+const chart = createChart(container, { autoSize: true, symbol: 'AAPL' });
+const series = chart.addCandlestickSeries();
+series.setData(initialData);
+
+chart.subscribeVisibleRangeChange(async (range) => {
+  const info = series.barsInLogicalRange({ from: 0, to: range.from });
+  if (info.barsBefore <= 20) {
+    const olderBars = await fetchOlderData();
+    series.prependData(olderBars);
+  }
+});
+      `,
+    });
   },
 };

--- a/stories/Features/Periodicity.stories.ts
+++ b/stories/Features/Periodicity.stories.ts
@@ -4,6 +4,7 @@ import type { Periodicity } from 'fin-charter';
 import type { Bar } from '../../src/core/types';
 import { createChartContainer, generateOHLCV } from '../helpers';
 import { AAPL_DAILY } from '../sample-data';
+import { withDocs } from '../doc-renderer';
 
 const meta: Meta = {
   title: 'Features/Periodicity',
@@ -133,6 +134,23 @@ chart.fitContent();`,
 
     wrapper.appendChild(toolbar);
     wrapper.appendChild(container);
-    return wrapper;
+    return withDocs(wrapper, {
+      description:
+        'Switch between different chart <strong>timeframes / periodicities</strong> such as ' +
+        '<code>1m</code>, <code>5m</code>, <code>1h</code>, and <code>1D</code>. ' +
+        'Call <code>chart.setPeriodicity({ interval, unit })</code> to change the interval, then reload data for that timeframe.',
+      code: `
+import { createChart } from 'fin-charter';
+
+const chart = createChart(container, { autoSize: true, symbol: 'AAPL' });
+const series = chart.addCandlestickSeries();
+series.setData(dailyData);
+
+// Switch to 5-minute bars
+chart.setPeriodicity({ interval: 5, unit: 'minute' });
+series.setData(fiveMinData);
+chart.fitContent();
+      `,
+    });
   },
 };

--- a/stories/Features/PriceLines.stories.ts
+++ b/stories/Features/PriceLines.stories.ts
@@ -1,6 +1,7 @@
 import type { Meta, StoryObj } from '@storybook/html';
 import { createChart } from 'fin-charter';
 import { createChartContainer } from '../helpers';
+import { withDocs } from '../doc-renderer';
 import { AAPL_DAILY } from '../sample-data';
 
 const meta: Meta = {
@@ -63,7 +64,26 @@ series.createPriceLine({
       axisLabelVisible: true,
     });
 
-    return container;
+    const description = '<strong>Price lines</strong> are horizontal lines anchored to a fixed price level. Use <code>series.createPriceLine(options)</code> to add support/resistance levels, stop-loss markers, or target prices. Each line can be styled with custom colors, line styles (<code>solid</code>, <code>dashed</code>, <code>dotted</code>), and optional axis labels.';
+    const code = `series.createPriceLine({
+  price: 185,
+  color: '#22AB94',
+  lineWidth: 1,
+  lineStyle: 'dashed',
+  title: 'Support',
+  axisLabelVisible: true,
+});
+
+series.createPriceLine({
+  price: 195,
+  color: '#F7525F',
+  lineWidth: 1,
+  lineStyle: 'dashed',
+  title: 'Resistance',
+  axisLabelVisible: true,
+});`;
+
+    return withDocs(container, { description, code });
   },
 };
 
@@ -126,6 +146,20 @@ series.createPriceLine({
       axisLabelTextColor: '#ffffff',
     });
 
-    return container;
+    const description = 'Use price lines to visualize <strong>trade levels</strong> such as entry, stop loss, and target prices. Combine different <code>lineStyle</code> values (<code>solid</code>, <code>dotted</code>, <code>dashed</code>) and custom <code>axisLabelColor</code> / <code>axisLabelTextColor</code> to distinguish each level at a glance.';
+    const code = `series.createPriceLine({
+  price: 190, color: '#2196F3', lineStyle: 'solid', title: 'Entry',
+  axisLabelVisible: true,
+});
+series.createPriceLine({
+  price: 182, color: '#F7525F', lineStyle: 'dotted', title: 'Stop Loss',
+  axisLabelVisible: true, axisLabelColor: '#F7525F',
+});
+series.createPriceLine({
+  price: 210, color: '#22AB94', lineStyle: 'dotted', title: 'Target',
+  axisLabelVisible: true, axisLabelColor: '#22AB94',
+});`;
+
+    return withDocs(container, { description, code });
   },
 };

--- a/stories/Features/Screenshot.stories.ts
+++ b/stories/Features/Screenshot.stories.ts
@@ -1,6 +1,7 @@
 import type { Meta, StoryObj } from '@storybook/html';
 import { createChart } from 'fin-charter';
 import { createChartContainer } from '../helpers';
+import { withDocs } from '../doc-renderer';
 import { AAPL_DAILY } from '../sample-data';
 
 const meta: Meta = {
@@ -72,6 +73,19 @@ const dataUrl = canvas.toDataURL('image/png');`,
     wrapper.appendChild(label);
     wrapper.appendChild(img);
 
-    return wrapper;
+    const description = 'Export the chart as an image with <code>chart.takeScreenshot()</code>. This returns an HTML <code>&lt;canvas&gt;</code> element that you can convert to a data URL via <code>canvas.toDataURL(\'image/png\')</code> for download or display. Click the button above to try it.';
+    const code = `const chart = createChart(container, { autoSize: true, symbol: 'AAPL' });
+const series = chart.addCandlestickSeries();
+series.setData(data);
+
+// Capture the chart as a canvas
+const canvas = chart.takeScreenshot();
+const dataUrl = canvas.toDataURL('image/png');
+
+// Use the data URL for download or display
+const img = document.createElement('img');
+img.src = dataUrl;`;
+
+    return withDocs(wrapper, { description, code });
   },
 };

--- a/stories/Features/SeriesMarkers.stories.ts
+++ b/stories/Features/SeriesMarkers.stories.ts
@@ -1,6 +1,7 @@
 import type { Meta, StoryObj } from '@storybook/html';
 import { createChart } from 'fin-charter';
 import { createChartContainer } from '../helpers';
+import { withDocs } from '../doc-renderer';
 import { AAPL_DAILY } from '../sample-data';
 
 const meta: Meta = {
@@ -67,7 +68,17 @@ series.setMarkers([
       },
     ]);
 
-    return container;
+    const description = '<strong>Series markers</strong> annotate specific bars with buy/sell signals or other labels. Call <code>series.setMarkers(array)</code> with objects specifying <code>time</code>, <code>position</code> (<code>belowBar</code>, <code>aboveBar</code>, <code>inBar</code>), <code>shape</code> (<code>arrowUp</code>, <code>arrowDown</code>, <code>circle</code>), <code>color</code>, and <code>text</code>.';
+    const code = `series.setMarkers([
+  { time: buyTime, position: 'belowBar', shape: 'arrowUp',
+    color: '#22AB94', text: 'Buy' },
+  { time: sellTime, position: 'aboveBar', shape: 'arrowDown',
+    color: '#F7525F', text: 'Sell' },
+  { time: signalTime, position: 'belowBar', shape: 'circle',
+    color: '#2196F3', text: 'Signal' },
+]);`;
+
+    return withDocs(container, { description, code });
   },
 };
 
@@ -99,6 +110,13 @@ export const MultipleMarkers: Story = {
       { time: AAPL_DAILY[160].time, position: 'belowBar', shape: 'circle', color: '#2196F3', text: 'Signal' },
     ]);
 
-    return container;
+    const description = 'Place <strong>multiple markers</strong> across the chart to highlight a sequence of trading signals. Markers are sorted by <code>time</code> automatically. Mix different shapes and positions to convey distinct signal types at a glance.';
+    const code = `series.setMarkers([
+  { time: t1, position: 'belowBar', shape: 'arrowUp', color: '#22AB94', text: 'Buy 1' },
+  { time: t2, position: 'aboveBar', shape: 'arrowDown', color: '#F7525F', text: 'Sell 1' },
+  { time: t3, position: 'inBar', shape: 'circle', color: '#FF9800', text: 'Alert' },
+]);`;
+
+    return withDocs(container, { description, code });
   },
 };

--- a/stories/Features/TimeFormatter.stories.ts
+++ b/stories/Features/TimeFormatter.stories.ts
@@ -2,6 +2,7 @@ import type { Meta, StoryObj } from '@storybook/html';
 import { createChart } from 'fin-charter';
 import { createChartContainer } from '../helpers';
 import { AAPL_DAILY } from '../sample-data';
+import { withDocs } from '../doc-renderer';
 
 const meta: Meta = {
   title: 'Features/Time Formatter',
@@ -64,6 +65,29 @@ const chart = createChart(container, {
     const series = chart.addCandlestickSeries();
     series.setData(AAPL_DAILY);
 
-    return container;
+    return withDocs(container, {
+      description:
+        'Customize <strong>time axis labels</strong> with a <code>tickMarkFormatter</code> callback. ' +
+        'The formatter receives the Unix timestamp and tick type (<code>"year"</code>, <code>"month"</code>, ' +
+        '<code>"day"</code>, <code>"time"</code>) and returns a formatted string. ' +
+        'This demo formats day ticks as <code>MM/DD</code>.',
+      code: `
+import { createChart } from 'fin-charter';
+
+const chart = createChart(container, {
+  autoSize: true,
+  symbol: 'AAPL',
+  timeScale: {
+    tickMarkFormatter: (time: number, tickType: string) => {
+      if (tickType === 'day') {
+        const d = new Date(time * 1000);
+        return \`\${d.getUTCMonth() + 1}/\${d.getUTCDate()}\`;
+      }
+      return '';
+    },
+  },
+});
+      `,
+    });
   },
 };

--- a/stories/Features/VolumeOverlay.stories.ts
+++ b/stories/Features/VolumeOverlay.stories.ts
@@ -1,6 +1,7 @@
 import type { Meta, StoryObj } from '@storybook/html';
 import { createChart } from 'fin-charter';
 import { createChartContainer } from '../helpers';
+import { withDocs } from '../doc-renderer';
 import { AAPL_DAILY } from '../sample-data';
 
 const meta: Meta = {
@@ -45,7 +46,17 @@ series.setData(data);`,
     });
     const series = chart.addCandlestickSeries();
     series.setData(AAPL_DAILY);
-    return container;
+
+    const description = 'Enable the built-in <strong>volume overlay</strong> with <code>volume: { visible: true }</code>. Volume bars render at the bottom of the chart using the same up/down color conventions as the candlesticks, providing a quick visual read on trading activity.';
+    const code = `const chart = createChart(container, {
+  autoSize: true,
+  symbol: 'AAPL',
+  volume: { visible: true },
+});
+const series = chart.addCandlestickSeries();
+series.setData(data);`;
+
+    return withDocs(container, { description, code });
   },
 };
 
@@ -84,6 +95,18 @@ export const CustomVolumeColors: Story = {
       wickDownColor: '#ff4081',
     });
     series.setData(AAPL_DAILY);
-    return container;
+
+    const description = 'Customize volume bar colors with <code>upColor</code> and <code>downColor</code> in the <code>volume</code> options. Use rgba values for semi-transparent overlays that blend with the chart background. Pair with matching candlestick colors for a cohesive look.';
+    const code = `const chart = createChart(container, {
+  autoSize: true,
+  symbol: 'AAPL',
+  volume: {
+    visible: true,
+    upColor: 'rgba(0, 229, 255, 0.5)',
+    downColor: 'rgba(255, 64, 129, 0.5)',
+  },
+});`;
+
+    return withDocs(container, { description, code });
   },
 };

--- a/stories/Features/Watermark.stories.ts
+++ b/stories/Features/Watermark.stories.ts
@@ -1,6 +1,7 @@
 import type { Meta, StoryObj } from '@storybook/html';
 import { createChart } from 'fin-charter';
 import { createChartContainer } from '../helpers';
+import { withDocs } from '../doc-renderer';
 import { AAPL_DAILY } from '../sample-data';
 
 const meta: Meta = {
@@ -55,7 +56,22 @@ const chart = createChart(container, {
     });
     const series = chart.addCandlestickSeries();
     series.setData(AAPL_DAILY);
-    return container;
+
+    const description = 'A <strong>watermark</strong> is a semi-transparent text label rendered behind the chart data. Use it to display the ticker symbol, data source, or branding. Configure with <code>watermark: { visible, text, fontSize, color, horzAlign, vertAlign }</code>.';
+    const code = `const chart = createChart(container, {
+  autoSize: true,
+  symbol: 'AAPL',
+  watermark: {
+    visible: true,
+    text: 'AAPL',
+    fontSize: 48,
+    color: 'rgba(255,255,255,0.08)',
+    horzAlign: 'center',
+    vertAlign: 'center',
+  },
+});`;
+
+    return withDocs(container, { description, code });
   },
 };
 
@@ -97,7 +113,20 @@ export const LargeText: Story = {
       bottomColor: 'rgba(0, 229, 255, 0.0)',
     });
     series.setData(AAPL_DAILY);
-    return container;
+
+    const description = 'Use a <strong>large watermark</strong> with custom colors for prominent branding. Combine with area series or other chart types for a distinctive look. Adjust <code>fontSize</code> and <code>color</code> opacity to control visibility.';
+    const code = `const chart = createChart(container, {
+  autoSize: true,
+  symbol: 'AAPL',
+  watermark: {
+    visible: true,
+    text: 'FIN-CHARTER',
+    fontSize: 64,
+    color: 'rgba(0, 229, 255, 0.06)',
+  },
+});`;
+
+    return withDocs(container, { description, code });
   },
 };
 
@@ -133,6 +162,20 @@ export const CornerWatermark: Story = {
     });
     const series = chart.addCandlestickSeries();
     series.setData(AAPL_DAILY);
-    return container;
+
+    const description = 'Position the watermark in any corner using <code>horzAlign</code> (<code>left</code>, <code>center</code>, <code>right</code>) and <code>vertAlign</code> (<code>top</code>, <code>center</code>, <code>bottom</code>). A smaller <code>fontSize</code> works well for corner placements.';
+    const code = `const chart = createChart(container, {
+  autoSize: true,
+  symbol: 'AAPL',
+  watermark: {
+    visible: true,
+    text: 'DEMO',
+    fontSize: 32,
+    horzAlign: 'right',
+    vertAlign: 'bottom',
+  },
+});`;
+
+    return withDocs(container, { description, code });
   },
 };

--- a/stories/HollowCandleChart.stories.ts
+++ b/stories/HollowCandleChart.stories.ts
@@ -2,6 +2,7 @@ import type { Meta, StoryObj } from '@storybook/html';
 import { createChart } from 'fin-charter';
 import { createChartContainer } from './helpers';
 import { AAPL_DAILY } from './sample-data';
+import { withDocs } from './doc-renderer';
 
 const meta: Meta = {
   title: 'Chart Types/Hollow Candle',
@@ -38,7 +39,22 @@ series.setData(data);
     const chart = createChart(container, { autoSize: true, symbol: 'AAPL' });
     const series = chart.addHollowCandleSeries();
     series.setData(AAPL_DAILY);
-    return container;
+    return withDocs(container, {
+      description:
+        '<strong>Hollow candle</strong> charts use the same OHLC data as regular candlesticks but render bullish bars as hollow (outline only) ' +
+        'and bearish bars as filled. This provides an additional visual dimension: the fill state indicates bullish vs bearish direction, ' +
+        'while the color can encode a separate dimension such as trend continuation.',
+      code: `
+import { createChart } from 'fin-charter';
+
+const chart = createChart(document.getElementById('chart'), {
+  autoSize: true,
+  symbol: 'AAPL',
+});
+const series = chart.addHollowCandleSeries();
+series.setData(data);
+      `,
+    });
   },
 };
 
@@ -67,6 +83,18 @@ series.setData(data);
       wickColor: '#aaaaaa',
     });
     series.setData(AAPL_DAILY);
-    return container;
+    return withDocs(container, {
+      description:
+        'Customize hollow candle colors with <code>upColor</code>, <code>downColor</code>, and <code>wickColor</code>. ' +
+        'The <code>wickColor</code> option sets a uniform wick color for both directions.',
+      code: `
+const series = chart.addHollowCandleSeries({
+  upColor: '#00e5ff',    // Bullish candle border/fill
+  downColor: '#ff4081',  // Bearish candle fill
+  wickColor: '#aaaaaa',  // Wick color for both directions
+});
+series.setData(data);
+      `,
+    });
   },
 };

--- a/stories/Indicators-Extended.stories.ts
+++ b/stories/Indicators-Extended.stories.ts
@@ -11,6 +11,7 @@ import {
 import type { Bar } from '../src/core/types';
 import { createChartContainer } from './helpers';
 import { AAPL_DAILY } from './sample-data';
+import { withDocs } from './doc-renderer';
 
 const meta: Meta = {
   title: 'Indicators/Extended Indicators',
@@ -76,7 +77,14 @@ chart.addLineSeries({ color: '#ff9800', lineWidth: 2 }).setData(vwapBars);`,
     const vwapSeries = chart.addLineSeries({ color: '#ff9800', lineWidth: 2 });
     vwapSeries.setData(indicatorToLineBars(store.time, vwapValues, len));
 
-    return container;
+    return withDocs(container, {
+      description:
+        '<strong>VWAP (Volume-Weighted Average Price)</strong> — Measures the average price weighted by volume throughout the session. Computed via <code>computeVWAP(high, low, close, volume, length)</code>. Used as an overlay to identify whether the current price is trading above or below fair value.',
+      code: `import { computeVWAP } from 'fin-charter/indicators';
+
+const vwap = computeVWAP(high, low, close, volume, bars.length);
+chart.addLineSeries({ color: '#ff9800', lineWidth: 2 }).setData(vwapBars);`,
+    });
   },
 };
 
@@ -111,7 +119,16 @@ export const StochasticOscillator: Story = {
       label: 'Stoch 14,3',
     });
 
-    return container;
+    return withDocs(container, {
+      description:
+        '<strong>Stochastic Oscillator</strong> — A momentum indicator comparing a closing price to its price range over a given period. Key parameters: <code>kPeriod</code> (lookback, default 14) and <code>dPeriod</code> (signal smoothing, default 3). Values above 80 indicate overbought; below 20 indicate oversold.',
+      code: `chart.addIndicator('stochastic', {
+  source: candleSeries,
+  params: { kPeriod: 14, dPeriod: 3 },
+  color: '#22AB94',
+  label: 'Stoch 14,3',
+});`,
+    });
   },
 };
 
@@ -146,7 +163,16 @@ export const ATRIndicator: Story = {
       label: 'ATR 14',
     });
 
-    return container;
+    return withDocs(container, {
+      description:
+        '<strong>ATR (Average True Range)</strong> — Measures market volatility by computing the average of true ranges over a <code>period</code> (default 14). Higher ATR values indicate greater volatility. Displayed in a separate pane below the chart.',
+      code: `chart.addIndicator('atr', {
+  source: candleSeries,
+  params: { period: 14 },
+  color: '#F7525F',
+  label: 'ATR 14',
+});`,
+    });
   },
 };
 
@@ -181,7 +207,16 @@ export const ADXIndicator: Story = {
       label: 'ADX 14',
     });
 
-    return container;
+    return withDocs(container, {
+      description:
+        '<strong>ADX (Average Directional Index)</strong> — Measures the <em>strength</em> of a trend regardless of direction. A <code>period</code> of 14 is standard. ADX above 25 signals a strong trend; below 20 suggests a weak or ranging market.',
+      code: `chart.addIndicator('adx', {
+  source: candleSeries,
+  params: { period: 14 },
+  color: '#ffd54f',
+  label: 'ADX 14',
+});`,
+    });
   },
 };
 
@@ -214,7 +249,15 @@ export const OBVIndicator: Story = {
       label: 'OBV',
     });
 
-    return container;
+    return withDocs(container, {
+      description:
+        '<strong>OBV (On-Balance Volume)</strong> — A cumulative volume-based indicator that adds volume on up-closes and subtracts on down-closes. Rising OBV confirms an uptrend; divergence between OBV and price can signal a reversal. No additional parameters required.',
+      code: `chart.addIndicator('obv', {
+  source: candleSeries,
+  color: '#7c4dff',
+  label: 'OBV',
+});`,
+    });
   },
 };
 
@@ -249,6 +292,15 @@ export const WilliamsRIndicator: Story = {
       label: 'W%R 14',
     });
 
-    return container;
+    return withDocs(container, {
+      description:
+        '<strong>Williams %R</strong> — A momentum oscillator ranging from 0 to -100 that measures overbought/oversold levels. Key parameter: <code>period</code> (default 14). Values above -20 indicate overbought; below -80 indicate oversold conditions.',
+      code: `chart.addIndicator('williams-r', {
+  source: candleSeries,
+  params: { period: 14 },
+  color: '#00e5ff',
+  label: 'W%R 14',
+});`,
+    });
   },
 };

--- a/stories/Indicators-Production.stories.ts
+++ b/stories/Indicators-Production.stories.ts
@@ -2,6 +2,7 @@ import type { Meta, StoryObj } from '@storybook/html';
 import { createChart } from 'fin-charter';
 import { createChartContainer } from './helpers';
 import { AAPL_DAILY } from './sample-data';
+import { withDocs } from './doc-renderer';
 
 const meta: Meta = {
   title: 'Indicators/Production Indicators',
@@ -54,7 +55,15 @@ chart.addIndicator('ichimoku', {
       label: 'Ichimoku',
     });
 
-    return container;
+    return withDocs(container, {
+      description:
+        '<strong>Ichimoku Cloud</strong> — A comprehensive trend-following system that defines support/resistance, trend direction, and momentum at a glance. Key parameters: <code>tenkanPeriod</code> (conversion line, 9), <code>kijunPeriod</code> (base line, 26), and <code>senkouPeriod</code> (leading span B, 52). Price above the cloud is bullish; below is bearish.',
+      code: `chart.addIndicator('ichimoku', {
+  source: series,
+  params: { tenkanPeriod: 9, kijunPeriod: 26, senkouPeriod: 52 },
+  label: 'Ichimoku',
+});`,
+    });
   },
 };
 
@@ -89,7 +98,16 @@ export const ParabolicSAR: Story = {
       label: 'PSAR',
     });
 
-    return container;
+    return withDocs(container, {
+      description:
+        '<strong>Parabolic SAR (Stop and Reverse)</strong> — A trend-following overlay that places dots above or below price to indicate potential stop-loss levels and trend direction. Key parameters: <code>afStep</code> (acceleration factor increment, 0.02) and <code>afMax</code> (maximum acceleration, 0.20).',
+      code: `chart.addIndicator('parabolic-sar', {
+  source: series,
+  params: { afStep: 0.02, afMax: 0.20 },
+  color: '#ff9800',
+  label: 'PSAR',
+});`,
+    });
   },
 };
 
@@ -124,7 +142,16 @@ export const KeltnerChannel: Story = {
       label: 'KC(20,2)',
     });
 
-    return container;
+    return withDocs(container, {
+      description:
+        '<strong>Keltner Channel</strong> — A volatility-based envelope plotted around an EMA. The upper and lower bands are offset by a multiple of ATR. Key parameters: <code>emaPeriod</code> (20), <code>atrPeriod</code> (10), and <code>multiplier</code> (2). Breakouts beyond the channel suggest strong momentum.',
+      code: `chart.addIndicator('keltner', {
+  source: series,
+  params: { emaPeriod: 20, atrPeriod: 10, multiplier: 2 },
+  color: '#7c4dff',
+  label: 'KC(20,2)',
+});`,
+    });
   },
 };
 
@@ -159,7 +186,16 @@ export const DonchianChannel: Story = {
       label: 'DC(20)',
     });
 
-    return container;
+    return withDocs(container, {
+      description:
+        '<strong>Donchian Channel</strong> — Plots the highest high and lowest low over the last <code>period</code> (default 20) bars, forming a price channel. Breakouts above the upper band or below the lower band signal potential trend starts.',
+      code: `chart.addIndicator('donchian', {
+  source: series,
+  params: { period: 20 },
+  color: '#00e5ff',
+  label: 'DC(20)',
+});`,
+    });
   },
 };
 
@@ -194,7 +230,16 @@ export const CCIIndicator: Story = {
       label: 'CCI(20)',
     });
 
-    return container;
+    return withDocs(container, {
+      description:
+        '<strong>CCI (Commodity Channel Index)</strong> — Measures how far the current price deviates from its statistical mean. Key parameter: <code>period</code> (default 20). Values above +100 indicate overbought; below -100 indicate oversold. Originally designed for commodities but widely used across all markets.',
+      code: `chart.addIndicator('cci', {
+  source: series,
+  params: { period: 20 },
+  color: '#f06292',
+  label: 'CCI(20)',
+});`,
+    });
   },
 };
 
@@ -227,6 +272,14 @@ export const PivotPoints: Story = {
       label: 'Pivots',
     });
 
-    return container;
+    return withDocs(container, {
+      description:
+        '<strong>Pivot Points</strong> — Calculates support and resistance levels from the previous period\'s high, low, and close. Displays the central pivot (P) along with support (S1, S2) and resistance (R1, R2) lines. No additional parameters required beyond the source series.',
+      code: `chart.addIndicator('pivot-points', {
+  source: series,
+  color: '#ffd54f',
+  label: 'Pivots',
+});`,
+    });
   },
 };

--- a/stories/Indicators.stories.ts
+++ b/stories/Indicators.stories.ts
@@ -4,6 +4,7 @@ import { computeSMA, computeEMA } from 'fin-charter/indicators';
 import type { Bar } from '../src/core/types';
 import { createChartContainer } from './helpers';
 import { AAPL_DAILY } from './sample-data';
+import { withDocs } from './doc-renderer';
 
 const meta: Meta = {
   title: 'Indicators/Moving Averages',
@@ -75,7 +76,18 @@ chart.addLineSeries({ color: '#00e5ff', lineWidth: 2 }).setData(emaLineBars);`,
     const emaSeries = chart.addLineSeries({ color: '#00e5ff', lineWidth: 2 });
     emaSeries.setData(indicatorToLineBars(bars, emaValues));
 
-    return container;
+    return withDocs(container, {
+      description:
+        '<strong>SMA 20 + EMA 20</strong> — Computes a <code>computeSMA()</code> and <code>computeEMA()</code> from close prices using <code>fin-charter/indicators</code>, then overlays both as line series on a candlestick chart. The <strong>SMA</strong> (yellow) equally weights the last 20 closes, while the <strong>EMA</strong> (cyan) gives more weight to recent prices.',
+      code: `import { computeSMA, computeEMA } from 'fin-charter/indicators';
+
+const closes = new Float64Array(bars.map(b => b.close));
+const sma = computeSMA(closes, bars.length, 20);
+const ema = computeEMA(closes, bars.length, 20);
+
+chart.addLineSeries({ color: '#f4c430', lineWidth: 2 }).setData(smaBars);
+chart.addLineSeries({ color: '#00e5ff', lineWidth: 2 }).setData(emaBars);`,
+    });
   },
 };
 
@@ -105,7 +117,15 @@ smaSeries.setData(smaLineBars);`,
     const smaSeries = chart.addLineSeries({ color: '#ff9800', lineWidth: 2 });
     smaSeries.setData(indicatorToLineBars(bars, smaValues));
 
-    return container;
+    return withDocs(container, {
+      description:
+        '<strong>SMA 50 Overlay</strong> — A 50-period <code>computeSMA()</code> showing the longer-term trend direction. Prices above the SMA 50 suggest a bullish trend; prices below suggest bearish.',
+      code: `import { computeSMA } from 'fin-charter/indicators';
+
+const closes = new Float64Array(bars.map(b => b.close));
+const sma50 = computeSMA(closes, bars.length, 50);
+chart.addLineSeries({ color: '#ff9800', lineWidth: 2 }).setData(smaBars);`,
+    });
   },
 };
 
@@ -141,6 +161,17 @@ chart.addLineSeries({ color: '#00e5ff', lineWidth: 2 }).setData(ema26Bars);`,
     const ema26Series = chart.addLineSeries({ color: '#00e5ff', lineWidth: 2 });
     ema26Series.setData(indicatorToLineBars(bars, ema26));
 
-    return container;
+    return withDocs(container, {
+      description:
+        '<strong>Dual EMA Crossover (EMA 12 + EMA 26)</strong> — A classic signal generation strategy using <code>computeEMA()</code>. When the fast <strong>EMA 12</strong> (red) crosses above the slow <strong>EMA 26</strong> (cyan), it signals a potential buy; crossing below signals a potential sell.',
+      code: `import { computeEMA } from 'fin-charter/indicators';
+
+const closes = new Float64Array(bars.map(b => b.close));
+const ema12 = computeEMA(closes, bars.length, 12);
+const ema26 = computeEMA(closes, bars.length, 26);
+
+chart.addLineSeries({ color: '#ff6b6b', lineWidth: 2 }).setData(ema12Bars);
+chart.addLineSeries({ color: '#00e5ff', lineWidth: 2 }).setData(ema26Bars);`,
+    });
   },
 };

--- a/stories/Indicators/NewIndicators.stories.ts
+++ b/stories/Indicators/NewIndicators.stories.ts
@@ -1,6 +1,7 @@
 import type { Meta, StoryObj } from '@storybook/html';
 import { createChart } from 'fin-charter';
 import { generateOHLCV, createChartContainer } from '../helpers';
+import { withDocs } from '../doc-renderer';
 
 const meta: Meta = {
   title: 'Indicators/New Indicators',
@@ -54,7 +55,16 @@ chart.addIndicator('aroon', {
       label: 'Aroon(25)',
     });
 
-    return container;
+    return withDocs(container, {
+      description:
+        '<strong>Aroon</strong> — Identifies trend changes and trend strength by measuring how long since the highest high and lowest low within a <code>period</code> (default 25). Aroon Up near 100 signals a strong uptrend; Aroon Down near 100 signals a strong downtrend.',
+      code: `chart.addIndicator('aroon', {
+  source: series,
+  params: { period: 25 },
+  color: '#22AB94',
+  label: 'Aroon(25)',
+});`,
+    });
   },
 };
 
@@ -89,7 +99,16 @@ export const AwesomeOscillator: Story = {
       label: 'AO(5,34)',
     });
 
-    return container;
+    return withDocs(container, {
+      description:
+        '<strong>Awesome Oscillator</strong> — Measures market momentum by comparing a <code>fastPeriod</code> (5) SMA of median prices to a <code>slowPeriod</code> (34) SMA. Positive values indicate bullish momentum; negative values indicate bearish momentum. Zero-line crossovers generate trade signals.',
+      code: `chart.addIndicator('awesome-oscillator', {
+  source: series,
+  params: { fastPeriod: 5, slowPeriod: 34 },
+  color: '#2196F3',
+  label: 'AO(5,34)',
+});`,
+    });
   },
 };
 
@@ -124,7 +143,16 @@ export const ChaikinMF: Story = {
       label: 'CMF(20)',
     });
 
-    return container;
+    return withDocs(container, {
+      description:
+        '<strong>Chaikin Money Flow</strong> — Measures the accumulation/distribution of money flow volume over a <code>period</code> (default 20). Values above 0 indicate buying pressure; below 0 indicate selling pressure. Sustained readings above/below zero confirm trend strength.',
+      code: `chart.addIndicator('chaikin-mf', {
+  source: series,
+  params: { period: 20 },
+  color: '#FF9800',
+  label: 'CMF(20)',
+});`,
+    });
   },
 };
 
@@ -159,7 +187,16 @@ export const CoppockCurve: Story = {
       label: 'Coppock',
     });
 
-    return container;
+    return withDocs(container, {
+      description:
+        '<strong>Coppock Curve</strong> — A long-term momentum indicator originally designed to identify buying opportunities in stock indices. Computed as a weighted moving average (<code>wmaPeriod</code>: 10) of the sum of two rates of change (<code>longROC</code>: 14, <code>shortROC</code>: 11). A zero-line crossover from below signals a potential buy.',
+      code: `chart.addIndicator('coppock', {
+  source: series,
+  params: { wmaPeriod: 10, longROC: 14, shortROC: 11 },
+  color: '#9C27B0',
+  label: 'Coppock',
+});`,
+    });
   },
 };
 
@@ -194,7 +231,16 @@ export const ElderForce: Story = {
       label: 'EFI(13)',
     });
 
-    return container;
+    return withDocs(container, {
+      description:
+        '<strong>Elder Force Index</strong> — Combines price change and volume to measure the power behind a price move. Smoothed with an EMA of <code>period</code> (default 13). Positive values indicate bulls are in control; negative values indicate bears dominate.',
+      code: `chart.addIndicator('elder-force', {
+  source: series,
+  params: { period: 13 },
+  color: '#F44336',
+  label: 'EFI(13)',
+});`,
+    });
   },
 };
 
@@ -229,7 +275,16 @@ export const TRIXIndicator: Story = {
       label: 'TRIX(15,9)',
     });
 
-    return container;
+    return withDocs(container, {
+      description:
+        '<strong>TRIX</strong> — A triple-smoothed EMA oscillator that filters out insignificant price movements. Key parameters: <code>period</code> (15) for the triple EMA and <code>signalPeriod</code> (9) for the signal line. Crossovers between TRIX and its signal line generate trade signals.',
+      code: `chart.addIndicator('trix', {
+  source: series,
+  params: { period: 15, signalPeriod: 9 },
+  color: '#00E5FF',
+  label: 'TRIX(15,9)',
+});`,
+    });
   },
 };
 
@@ -264,7 +319,16 @@ export const SupertrendIndicator: Story = {
       label: 'ST(10,3)',
     });
 
-    return container;
+    return withDocs(container, {
+      description:
+        '<strong>Supertrend</strong> — A trend-following overlay based on ATR that flips between support and resistance. Key parameters: <code>period</code> (10) for ATR calculation and <code>multiplier</code> (3) for band offset. Green line below price indicates uptrend; red line above indicates downtrend.',
+      code: `chart.addIndicator('supertrend', {
+  source: series,
+  params: { period: 10, multiplier: 3 },
+  color: '#4CAF50',
+  label: 'ST(10,3)',
+});`,
+    });
   },
 };
 
@@ -299,7 +363,16 @@ export const VWMAIndicator: Story = {
       label: 'VWMA(20)',
     });
 
-    return container;
+    return withDocs(container, {
+      description:
+        '<strong>VWMA (Volume-Weighted Moving Average)</strong> — A moving average that weights each bar\'s price by its volume over a <code>period</code> (default 20). Unlike a simple SMA, VWMA gives more influence to high-volume bars. Displayed as a price overlay.',
+      code: `chart.addIndicator('vwma', {
+  source: series,
+  params: { period: 20 },
+  color: '#FF5722',
+  label: 'VWMA(20)',
+});`,
+    });
   },
 };
 
@@ -334,7 +407,16 @@ export const ChoppinessIndex: Story = {
       label: 'CHOP(14)',
     });
 
-    return container;
+    return withDocs(container, {
+      description:
+        '<strong>Choppiness Index</strong> — Determines whether the market is trending or trading sideways. Ranges from 0 to 100 over the given <code>period</code> (default 14). Values above 61.8 suggest a choppy, range-bound market; below 38.2 suggest a strong trend.',
+      code: `chart.addIndicator('choppiness', {
+  source: series,
+  params: { period: 14 },
+  color: '#FFC107',
+  label: 'CHOP(14)',
+});`,
+    });
   },
 };
 
@@ -369,7 +451,16 @@ export const MFIIndicator: Story = {
       label: 'MFI(14)',
     });
 
-    return container;
+    return withDocs(container, {
+      description:
+        '<strong>MFI (Money Flow Index)</strong> — A volume-weighted RSI that oscillates between 0 and 100 over a <code>period</code> (default 14). Values above 80 indicate overbought conditions; below 20 indicate oversold. Incorporates both price and volume to gauge buying/selling pressure.',
+      code: `chart.addIndicator('mfi', {
+  source: series,
+  params: { period: 14 },
+  color: '#E91E63',
+  label: 'MFI(14)',
+});`,
+    });
   },
 };
 
@@ -404,7 +495,16 @@ export const ROCIndicator: Story = {
       label: 'ROC(12)',
     });
 
-    return container;
+    return withDocs(container, {
+      description:
+        '<strong>ROC (Rate of Change)</strong> — Measures the percentage change in price over a <code>period</code> (default 12). Positive values indicate upward momentum; negative values indicate downward momentum. Zero-line crossovers can signal trend shifts.',
+      code: `chart.addIndicator('roc', {
+  source: series,
+  params: { period: 12 },
+  color: '#607D8B',
+  label: 'ROC(12)',
+});`,
+    });
   },
 };
 
@@ -439,6 +539,15 @@ export const LinearRegressionIndicator: Story = {
       label: 'LinReg(25)',
     });
 
-    return container;
+    return withDocs(container, {
+      description:
+        '<strong>Linear Regression</strong> — Fits a least-squares regression line to the last <code>period</code> (default 25) closing prices. The overlay shows where price "should" be based on the trend, helping identify deviations and mean-reversion opportunities.',
+      code: `chart.addIndicator('linear-regression', {
+  source: series,
+  params: { period: 25 },
+  color: '#3F51B5',
+  label: 'LinReg(25)',
+});`,
+    });
   },
 };

--- a/stories/LineChart.stories.ts
+++ b/stories/LineChart.stories.ts
@@ -2,6 +2,7 @@ import type { Meta, StoryObj } from '@storybook/html';
 import { createChart } from 'fin-charter';
 import { createChartContainer } from './helpers';
 import { AAPL_DAILY } from './sample-data';
+import { withDocs } from './doc-renderer';
 
 const meta: Meta = {
   title: 'Chart Types/Line',
@@ -37,7 +38,22 @@ series.setData(data);
     const chart = createChart(container, { autoSize: true, symbol: 'AAPL' });
     const series = chart.addLineSeries();
     series.setData(AAPL_DAILY);
-    return container;
+    return withDocs(container, {
+      description:
+        'A <strong>line chart</strong> connects the close price of each bar with a smooth polyline. ' +
+        'It is the simplest chart type and is ideal for showing price trends at a glance.\n' +
+        'The chart uses the <code>close</code> field from each data point for the Y value.',
+      code: `
+import { createChart } from 'fin-charter';
+
+const chart = createChart(document.getElementById('chart'), {
+  autoSize: true,
+  symbol: 'AAPL',
+});
+const series = chart.addLineSeries();
+series.setData(data); // Uses the 'close' field from each bar
+      `,
+    });
   },
 };
 
@@ -64,7 +80,18 @@ series.setData(data);
       lineWidth: 2,
     });
     series.setData(AAPL_DAILY);
-    return container;
+    return withDocs(container, {
+      description:
+        'Customize the line appearance with <code>color</code> and <code>lineWidth</code>. ' +
+        'Any valid CSS color value is accepted.',
+      code: `
+const series = chart.addLineSeries({
+  color: '#00e5ff',   // Cyan line
+  lineWidth: 2,       // 2px width
+});
+series.setData(data);
+      `,
+    });
   },
 };
 
@@ -85,6 +112,14 @@ series.setData(data);
     const chart = createChart(container, { autoSize: true, symbol: 'AAPL' });
     const series = chart.addLineSeries({ color: '#ff6b6b' });
     series.setData(AAPL_DAILY);
-    return container;
+    return withDocs(container, {
+      description:
+        'Line charts are effective for visualizing volatile price action. ' +
+        'The red line color here is commonly used to indicate bearish or high-risk instruments.',
+      code: `
+const series = chart.addLineSeries({ color: '#ff6b6b' });
+series.setData(data);
+      `,
+    });
   },
 };

--- a/stories/MultiSeries.stories.ts
+++ b/stories/MultiSeries.stories.ts
@@ -2,6 +2,7 @@ import type { Meta, StoryObj } from '@storybook/html';
 import { createChart } from 'fin-charter';
 import { createChartContainer } from './helpers';
 import { AAPL_DAILY } from './sample-data';
+import { withDocs } from './doc-renderer';
 
 const meta: Meta = {
   title: 'Features/Multiple Series',
@@ -43,7 +44,6 @@ series2.setData(stockB);
     const series1 = chart.addLineSeries({ color: '#2962FF', lineWidth: 2 });
     series1.setData(AAPL_DAILY);
 
-    // Shift all prices by a fixed offset to simulate a second instrument
     const shifted = AAPL_DAILY.map((b) => ({
       ...b,
       open: b.open - 10,
@@ -54,7 +54,24 @@ series2.setData(stockB);
     const series2 = chart.addLineSeries({ color: '#FF6D00', lineWidth: 2 });
     series2.setData(shifted);
 
-    return container;
+    return withDocs(container, {
+      description:
+        'Multiple series can be overlaid on the same chart by calling <code>addLineSeries()</code> (or any series type) multiple times. ' +
+        'Each series gets its own data and style but shares the time axis and price scale.',
+      code: `
+import { createChart } from 'fin-charter';
+
+const chart = createChart(container, { autoSize: true, symbol: 'AAPL' });
+
+// First series
+const series1 = chart.addLineSeries({ color: '#2962FF', lineWidth: 2 });
+series1.setData(stockA);
+
+// Second series overlaid on the same chart
+const series2 = chart.addLineSeries({ color: '#FF6D00', lineWidth: 2 });
+series2.setData(stockB);
+      `,
+    });
   },
 };
 
@@ -80,7 +97,6 @@ sma.setData(smaData);
     const candleSeries = chart.addCandlestickSeries();
     candleSeries.setData(AAPL_DAILY);
 
-    // SMA-like overlay computed from AAPL_DAILY
     const smaData = AAPL_DAILY.map((bar, i) => {
       const slice = AAPL_DAILY.slice(Math.max(0, i - 19), i + 1);
       const avg = slice.reduce((s, b) => s + b.close, 0) / slice.length;
@@ -90,7 +106,19 @@ sma.setData(smaData);
     const lineSeries = chart.addLineSeries({ color: '#FF6D00', lineWidth: 2 });
     lineSeries.setData(smaData);
 
-    return container;
+    return withDocs(container, {
+      description:
+        'Combine different series types on the same chart. Here a <strong>candlestick series</strong> shows OHLC data while a <strong>line series</strong> ' +
+        'overlays a simple moving average (SMA). This is a common pattern for adding indicator overlays manually.',
+      code: `
+const candles = chart.addCandlestickSeries();
+candles.setData(ohlcData);
+
+// Overlay a moving average as a line series
+const sma = chart.addLineSeries({ color: '#FF6D00', lineWidth: 2 });
+sma.setData(smaData);
+      `,
+    });
   },
 };
 
@@ -121,7 +149,19 @@ chart.addCandlestickSeries().setData(data);
     const series = chart.addCandlestickSeries();
     series.setData(AAPL_DAILY);
 
-    return container;
+    return withDocs(container, {
+      description:
+        'Enable the built-in <strong>volume overlay</strong> with <code>volume: { visible: true }</code>. ' +
+        'Volume bars appear at the bottom of the chart using the same up/down color convention as the candles.',
+      code: `
+const chart = createChart(container, {
+  autoSize: true,
+  symbol: 'AAPL',
+  volume: { visible: true },  // Enable volume overlay
+});
+chart.addCandlestickSeries().setData(data);
+      `,
+    });
   },
 };
 
@@ -169,7 +209,30 @@ series.createPriceLine({
       axisLabelColor: '#F7525F', axisLabelTextColor: '#ffffff',
     });
 
-    return container;
+    return withDocs(container, {
+      description:
+        'Annotate charts with <strong>markers</strong> (buy/sell signals, info points) and <strong>price lines</strong> (support/resistance levels).\n' +
+        'Use <code>series.setMarkers()</code> with <code>position</code> (belowBar, aboveBar, inBar), <code>shape</code> (arrowUp, arrowDown, circle), ' +
+        'and <code>text</code>. Use <code>series.createPriceLine()</code> with <code>price</code>, <code>color</code>, <code>lineStyle</code>, and <code>title</code>.',
+      code: `
+// Add trading signal markers
+series.setMarkers([
+  { time: t1, position: 'belowBar', shape: 'arrowUp', color: '#22AB94', text: 'Buy' },
+  { time: t2, position: 'aboveBar', shape: 'arrowDown', color: '#F7525F', text: 'Sell' },
+  { time: t3, position: 'inBar', shape: 'circle', color: '#2962FF', text: 'Info' },
+]);
+
+// Add support / resistance price lines
+series.createPriceLine({
+  price: 150,
+  color: '#22AB94',
+  lineWidth: 1,
+  lineStyle: 'dashed',
+  title: 'Support',
+  axisLabelVisible: true,
+});
+      `,
+    });
   },
 };
 
@@ -212,6 +275,26 @@ chart.addCandlestickSeries().setData(data);
     const series = chart.addCandlestickSeries();
     series.setData(AAPL_DAILY);
 
-    return container;
+    return withDocs(container, {
+      description:
+        'Add a <strong>watermark</strong> behind the chart content using the <code>watermark</code> option. ' +
+        'Configure <code>text</code>, <code>fontSize</code>, <code>color</code> (use semi-transparent), and alignment ' +
+        '(<code>horzAlign</code>: center/left/right, <code>vertAlign</code>: center/top/bottom).',
+      code: `
+const chart = createChart(container, {
+  autoSize: true,
+  symbol: 'AAPL',
+  watermark: {
+    visible: true,
+    text: 'AAPL',
+    color: 'rgba(255,255,255,0.08)',
+    fontSize: 64,
+    horzAlign: 'center',
+    vertAlign: 'center',
+  },
+});
+chart.addCandlestickSeries().setData(data);
+      `,
+    });
   },
 };

--- a/stories/Navigation/GoToRealtime.stories.ts
+++ b/stories/Navigation/GoToRealtime.stories.ts
@@ -2,6 +2,7 @@ import type { Meta, StoryObj } from '@storybook/html';
 import { createChart } from 'fin-charter';
 import type { Bar } from '../../src/core/types';
 import { generateOHLCV, createChartContainer } from '../helpers';
+import { withDocs } from '../doc-renderer';
 
 const meta: Meta = {
   title: 'Navigation/Go to Realtime',
@@ -89,6 +90,17 @@ chart.scrollToRealTime();`,
     });
     observer.observe(document.body, { childList: true, subtree: true });
 
-    return root;
+    return withDocs(root, {
+      description:
+        '<strong>Go to Realtime</strong> snaps the chart viewport back to the most recent bar after the user has panned away. ' +
+        'Call <code>chart.scrollToRealTime()</code> to instantly scroll to the latest data point. ' +
+        'This story also streams new bars every second to demonstrate real-time updates.',
+      code: `const chart = createChart(container, { autoSize: true, symbol: 'AAPL' });
+const series = chart.addCandlestickSeries();
+series.setData(bars);
+
+// Snap the viewport to the most recent bar
+chart.scrollToRealTime();`,
+    });
   },
 };

--- a/stories/Navigation/InfiniteHistory.stories.ts
+++ b/stories/Navigation/InfiniteHistory.stories.ts
@@ -3,6 +3,7 @@ import { createChart } from 'fin-charter';
 import type { Bar } from '../../src/core/types';
 import { createChartContainer } from '../helpers';
 import { AAPL_DAILY } from '../sample-data';
+import { withDocs } from '../doc-renderer';
 
 const meta: Meta = {
   title: 'Navigation/Infinite History',
@@ -104,6 +105,25 @@ chart.subscribeVisibleRangeChange(async (range) => {
 
     root.appendChild(loadingEl);
     root.appendChild(container);
-    return root;
+    return withDocs(root, {
+      description:
+        'Load <strong>historical data on demand</strong> when the user pans to the left edge of the chart. ' +
+        'Subscribe to <code>chart.subscribeVisibleRangeChange()</code> and detect when <code>range.from</code> ' +
+        'reaches the earliest bar time, then fetch and prepend older data with <code>series.setData()</code>.',
+      code: `
+import { createChart } from 'fin-charter';
+
+const chart = createChart(container, { autoSize: true, symbol: 'AAPL' });
+const series = chart.addCandlestickSeries();
+series.setData(bars);
+
+chart.subscribeVisibleRangeChange(async (range) => {
+  if (range.from <= firstBarTime) {
+    const olderBars = await fetchHistory();
+    series.setData([...olderBars, ...bars]);
+  }
+});
+      `,
+    });
   },
 };

--- a/stories/Navigation/RangeSwitcher.stories.ts
+++ b/stories/Navigation/RangeSwitcher.stories.ts
@@ -2,6 +2,7 @@ import type { Meta, StoryObj } from '@storybook/html';
 import { createChart } from 'fin-charter';
 import { createChartContainer } from '../helpers';
 import { AAPL_DAILY } from '../sample-data';
+import { withDocs } from '../doc-renderer';
 
 const meta: Meta = {
   title: 'Navigation/Range Switcher',
@@ -117,6 +118,20 @@ chart.scrollToRealTime();`,
 
     root.appendChild(toolbar);
     root.appendChild(container);
-    return root;
+    return withDocs(root, {
+      description:
+        '<strong>Range Switcher</strong> provides quick navigation buttons for predefined time ranges ' +
+        '(<code>1M</code>, <code>3M</code>, <code>6M</code>, <code>1Y</code>, <code>ALL</code>). ' +
+        'Each button calls <code>chart.setVisibleRange(from, to)</code> to jump to the desired window. ' +
+        'The "Go to Realtime" button calls <code>chart.scrollToRealTime()</code> to snap back to the latest bar.',
+      code: `const DAY = 86400;
+const lastTime = bars[bars.length - 1].time;
+
+// Jump to a 3-month window
+chart.setVisibleRange(lastTime - 90 * DAY, lastTime);
+
+// Snap back to the latest bar
+chart.scrollToRealTime();`,
+    });
   },
 };

--- a/stories/RealTimeChart.stories.ts
+++ b/stories/RealTimeChart.stories.ts
@@ -2,6 +2,7 @@ import type { Meta, StoryObj } from '@storybook/html';
 import { createChart } from 'fin-charter';
 import type { Bar } from '../src/core/types';
 import { generateOHLCV, createChartContainer } from './helpers';
+import { withDocs } from './doc-renderer';
 
 const meta: Meta = {
   title: 'Real-Time/Streaming',
@@ -42,7 +43,6 @@ setInterval(() => {
     const chart = createChart(container, { autoSize: true, symbol: 'AAPL' });
     const series = chart.addCandlestickSeries();
 
-    // Seed with 100 historical bars
     const seedData = generateOHLCV(100);
     series.setData(seedData);
 
@@ -67,7 +67,6 @@ setInterval(() => {
       lastBar = newBar;
     }, 500);
 
-    // Clean up on story unmount via a MutationObserver watching container removal
     const observer = new MutationObserver(() => {
       if (!document.contains(container)) {
         clearInterval(intervalId);
@@ -77,7 +76,25 @@ setInterval(() => {
     });
     observer.observe(document.body, { childList: true, subtree: true });
 
-    return container;
+    return withDocs(container, {
+      description:
+        '<strong>Real-time streaming</strong> is achieved with <code>series.update(bar)</code>. When you pass a bar with a new timestamp, ' +
+        'it is appended to the chart. When the timestamp matches the last bar, it updates in place.\n' +
+        'This example appends a new candlestick every 500ms. Use a <code>MutationObserver</code> to clean up intervals when the story unmounts.',
+      code: `
+import { createChart } from 'fin-charter';
+
+const chart = createChart(container, { autoSize: true, symbol: 'AAPL' });
+const series = chart.addCandlestickSeries();
+series.setData(historicalBars);
+
+// Append a new bar every 500ms
+setInterval(() => {
+  const newBar = { time: nextTime, open, high, low, close, volume };
+  series.update(newBar); // New timestamp → appends; same timestamp → updates in place
+}, 500);
+      `,
+    });
   },
 };
 
@@ -109,7 +126,6 @@ setInterval(() => {
     const chart = createChart(container, { autoSize: true, symbol: 'AAPL' });
     const series = chart.addCandlestickSeries();
 
-    // Seed with 100 historical bars
     const seedData = generateOHLCV(100);
     series.setData(seedData);
 
@@ -128,7 +144,6 @@ setInterval(() => {
     let tickCount = 0;
 
     const intervalId = setInterval(() => {
-      // Simulate a price tick
       const tick = candle.close + (Math.random() - 0.48) * 0.5;
       candle = {
         ...candle,
@@ -140,7 +155,6 @@ setInterval(() => {
       series.update(candle);
 
       tickCount++;
-      // Every ~50 ticks (~5 seconds), start a new candle
       if (tickCount >= 50) {
         tickCount = 0;
         candleTime += 86400;
@@ -165,7 +179,24 @@ setInterval(() => {
     });
     observer.observe(document.body, { childList: true, subtree: true });
 
-    return container;
+    return withDocs(container, {
+      description:
+        '<strong>Candle building</strong> simulates tick-by-tick price updates within a single candle. ' +
+        'By calling <code>series.update()</code> with the same timestamp repeatedly, the candle\'s high, low, and close animate in real time.\n' +
+        'Every ~50 ticks (~5 seconds) a new candle starts. This mimics how live market data builds candles from individual trades.',
+      code: `
+// Start a new candle at the latest time + 1 day
+let candle = { time: nextTime, open: lastClose, high: lastClose, low: lastClose, close: lastClose, volume: 0 };
+
+setInterval(() => {
+  const tick = candle.close + (Math.random() - 0.48) * 0.5;
+  candle.high = Math.max(candle.high, tick);
+  candle.low = Math.min(candle.low, tick);
+  candle.close = tick;
+  series.update(candle); // Same timestamp → updates in place
+}, 100);
+      `,
+    });
   },
 };
 
@@ -213,6 +244,19 @@ setInterval(() => {
     });
     observer.observe(document.body, { childList: true, subtree: true });
 
-    return container;
+    return withDocs(container, {
+      description:
+        'Real-time streaming works with <strong>any series type</strong>, not just candlesticks. ' +
+        'Here a <code>LineSeries</code> is updated every 500ms. The line chart shows only the close price, making it ideal for ticker-style displays.',
+      code: `
+const series = chart.addLineSeries({ color: '#00e5ff', lineWidth: 2 });
+series.setData(historicalBars);
+
+// Stream new points every 500ms
+setInterval(() => {
+  series.update({ time: nextTime, open, high, low, close, volume: 0 });
+}, 500);
+      `,
+    });
   },
 };

--- a/stories/TradingView/TradingView.stories.ts
+++ b/stories/TradingView/TradingView.stories.ts
@@ -1,6 +1,7 @@
 import type { Meta, StoryObj } from '@storybook/html';
 import { mount, unmount } from 'svelte';
 import TradingViewApp from '../../dev/components/TradingViewApp.svelte';
+import { withDocs } from '../doc-renderer';
 
 const meta: Meta = {
   title: 'TradingView/Full Application',
@@ -57,6 +58,21 @@ export const Default: Story = {
 
     observer.observe(document.body, { childList: true, subtree: true });
 
-    return container;
+    return withDocs(container, {
+      description:
+        'A full <strong>TradingView-like charting application</strong> built with fin-charter and reusable Svelte components. ' +
+        'Features include <code>symbol search</code>, <code>interval switching</code>, <code>chart type selection</code>, ' +
+        '30+ technical indicators, 16 drawing tools, <code>comparison mode</code>, <code>timezone selection</code>, ' +
+        'a collapsible watchlist sidebar, and live Yahoo Finance data.',
+      code: `import { mount } from 'svelte';
+import TradingViewApp from './components/TradingViewApp.svelte';
+
+const container = document.createElement('div');
+container.style.width = '100%';
+container.style.height = '100vh';
+
+// Mount the full TradingView clone
+const app = mount(TradingViewApp, { target: container });`,
+    });
   },
 };

--- a/stories/doc-renderer.ts
+++ b/stories/doc-renderer.ts
@@ -1,0 +1,279 @@
+/**
+ * Custom story documentation renderer for fin-charter Storybook.
+ *
+ * Wraps each story with an inline documentation panel showing a description
+ * and a collapsible, syntax-highlighted code snippet — visible directly in the
+ * Canvas view so that users can learn from examples without switching to Docs.
+ */
+
+/* ------------------------------------------------------------------ */
+/*  Minimal syntax highlighting for TypeScript / JavaScript snippets  */
+/* ------------------------------------------------------------------ */
+
+const TOKEN_COLORS: Record<string, string> = {
+  keyword: '#c678dd',   // purple – import, const, let, new, function, …
+  string: '#98c379',    // green  – '…', "…", `…`
+  comment: '#5c6370',   // gray   – // … and /* … */
+  number: '#d19a66',    // orange – 42, 3.14
+  method: '#61afef',    // blue   – .addCandlestickSeries
+  property: '#e5c07b',  // yellow – object keys before ':'
+  type: '#e06c75',      // red    – type names after ':'
+  punctuation: '#abb2bf',
+  default: '#d1d4dc',
+};
+
+function highlightCode(code: string): string {
+  // Order matters – earlier rules win
+  const rules: Array<{ re: RegExp; cls: string }> = [
+    // Comments (single-line only for simplicity)
+    { re: /(\/\/[^\n]*)/g, cls: 'comment' },
+    // Strings (single-quoted, double-quoted, backtick)
+    { re: /('(?:[^'\\]|\\.)*'|"(?:[^"\\]|\\.)*"|`(?:[^`\\]|\\.)*`)/g, cls: 'string' },
+    // Keywords
+    {
+      re: /\b(import|from|export|default|const|let|var|function|return|if|else|new|true|false|null|undefined|typeof|void|async|await|class|extends|type|interface)\b/g,
+      cls: 'keyword',
+    },
+    // Numbers
+    { re: /\b(\d+(?:\.\d+)?)\b/g, cls: 'number' },
+    // Method calls  .foo(
+    { re: /\.([a-zA-Z_]\w*)\s*\(/g, cls: 'method' },
+    // Object keys   foo:
+    { re: /([a-zA-Z_]\w*)\s*:/g, cls: 'property' },
+  ];
+
+  // We build highlighted HTML by walking through the string, applying the
+  // first matching rule at each position.
+  let result = '';
+  let i = 0;
+  const len = code.length;
+
+  while (i < len) {
+    let earliest: { start: number; end: number; html: string } | null = null;
+
+    for (const { re, cls } of rules) {
+      re.lastIndex = i;
+      const m = re.exec(code);
+      if (!m) continue;
+
+      // For groups like .method( we want the group, not the full match
+      const matchStart = m.index;
+      const fullMatch = m[0];
+      const groupMatch = m[1] || fullMatch;
+
+      if (!earliest || matchStart < earliest.start) {
+        const color = TOKEN_COLORS[cls] || TOKEN_COLORS.default;
+
+        if (cls === 'method') {
+          // Wrap only the method name, keep the dot and paren
+          const beforeGroup = fullMatch.indexOf(groupMatch);
+          const pre = escapeHtml(fullMatch.slice(0, beforeGroup));
+          const post = escapeHtml(fullMatch.slice(beforeGroup + groupMatch.length));
+          earliest = {
+            start: matchStart,
+            end: matchStart + fullMatch.length,
+            html: pre + `<span style="color:${color}">${escapeHtml(groupMatch)}</span>` + post,
+          };
+        } else if (cls === 'property') {
+          const post = escapeHtml(fullMatch.slice(groupMatch.length));
+          earliest = {
+            start: matchStart,
+            end: matchStart + fullMatch.length,
+            html: `<span style="color:${color}">${escapeHtml(groupMatch)}</span>` + post,
+          };
+        } else {
+          earliest = {
+            start: matchStart,
+            end: matchStart + fullMatch.length,
+            html: `<span style="color:${color}">${escapeHtml(fullMatch)}</span>`,
+          };
+        }
+      }
+    }
+
+    if (earliest && earliest.start < len) {
+      // Emit plain text before the match
+      if (earliest.start > i) {
+        result += escapeHtml(code.slice(i, earliest.start));
+      }
+      result += earliest.html;
+      i = earliest.end;
+    } else {
+      // No more matches – emit the rest as plain text
+      result += escapeHtml(code.slice(i));
+      break;
+    }
+  }
+
+  return result;
+}
+
+function escapeHtml(text: string): string {
+  return text
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;');
+}
+
+/* ------------------------------------------------------------------ */
+/*  Public API                                                        */
+/* ------------------------------------------------------------------ */
+
+export interface DocOptions {
+  /** Short description shown above the chart. Supports simple line breaks. */
+  description: string;
+  /** Code snippet displayed in a collapsible block. */
+  code: string;
+  /** If true the code block starts expanded (default: true). */
+  codeExpanded?: boolean;
+}
+
+/**
+ * Wraps a story element with an inline documentation panel.
+ *
+ * Usage inside a Storybook render function:
+ * ```ts
+ * render: () => {
+ *   const container = createChartContainer();
+ *   const chart = createChart(container, { ... });
+ *   // … set up chart …
+ *   return withDocs(container, {
+ *     description: 'This story demonstrates …',
+ *     code: `const chart = createChart(…);`,
+ *   });
+ * }
+ * ```
+ */
+export function withDocs(
+  chartElement: HTMLElement,
+  opts: DocOptions,
+): HTMLElement {
+  const expanded = opts.codeExpanded !== false;
+
+  const wrapper = document.createElement('div');
+  wrapper.style.cssText = `
+    display: flex;
+    flex-direction: column;
+    gap: 0;
+    height: 100%;
+    font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, sans-serif;
+  `;
+
+  /* --- Doc panel (description + code) --- */
+  const docPanel = document.createElement('div');
+  docPanel.style.cssText = `
+    padding: 20px 24px 16px;
+    background: #13141f;
+    border-bottom: 1px solid #1e2235;
+    flex-shrink: 0;
+  `;
+
+  // Description
+  const desc = document.createElement('p');
+  desc.style.cssText = `
+    margin: 0 0 12px 0;
+    color: #b2b5be;
+    font-size: 14px;
+    line-height: 1.65;
+    max-width: 860px;
+  `;
+  desc.innerHTML = opts.description.replace(/\n/g, '<br>');
+  docPanel.appendChild(desc);
+
+  // Collapsible code block
+  const codeSection = document.createElement('div');
+  codeSection.style.cssText = `margin-top: 4px;`;
+
+  const toggle = document.createElement('button');
+  toggle.style.cssText = `
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    padding: 0;
+    border: none;
+    background: none;
+    color: #5d8ecf;
+    font-size: 12px;
+    font-family: inherit;
+    cursor: pointer;
+    margin-bottom: 8px;
+    letter-spacing: 0.3px;
+  `;
+  toggle.onmouseenter = () => { toggle.style.color = '#7db1ef'; };
+  toggle.onmouseleave = () => { toggle.style.color = '#5d8ecf'; };
+
+  const chevron = document.createElement('span');
+  chevron.style.cssText = `
+    display: inline-block;
+    transition: transform 0.15s ease;
+    font-size: 10px;
+  `;
+  chevron.textContent = '\u25B6'; // ▶
+  if (expanded) chevron.style.transform = 'rotate(90deg)';
+
+  const toggleLabel = document.createElement('span');
+  toggleLabel.textContent = 'Show code';
+
+  toggle.appendChild(chevron);
+  toggle.appendChild(toggleLabel);
+
+  const codeBlock = document.createElement('div');
+  codeBlock.style.cssText = `
+    background: #1a1b2e;
+    border: 1px solid #262840;
+    border-radius: 6px;
+    padding: 14px 18px;
+    overflow-x: auto;
+    max-height: 360px;
+    overflow-y: auto;
+    display: ${expanded ? 'block' : 'none'};
+  `;
+
+  const pre = document.createElement('pre');
+  pre.style.cssText = `
+    margin: 0;
+    font-family: 'SF Mono', 'Fira Code', 'JetBrains Mono', Menlo, Consolas, monospace;
+    font-size: 13px;
+    line-height: 1.55;
+    color: ${TOKEN_COLORS.default};
+    white-space: pre;
+    tab-size: 2;
+  `;
+  pre.innerHTML = highlightCode(dedent(opts.code));
+
+  codeBlock.appendChild(pre);
+  codeSection.appendChild(toggle);
+  codeSection.appendChild(codeBlock);
+  docPanel.appendChild(codeSection);
+
+  toggle.addEventListener('click', () => {
+    const isVisible = codeBlock.style.display !== 'none';
+    codeBlock.style.display = isVisible ? 'none' : 'block';
+    chevron.style.transform = isVisible ? 'rotate(0deg)' : 'rotate(90deg)';
+  });
+
+  /* --- Chart container --- */
+  const chartWrapper = document.createElement('div');
+  chartWrapper.style.cssText = `flex: 1; min-height: 0;`;
+  chartWrapper.appendChild(chartElement);
+  // Make chart fill remaining space
+  chartElement.style.height = '100%';
+
+  wrapper.appendChild(docPanel);
+  wrapper.appendChild(chartWrapper);
+
+  return wrapper;
+}
+
+/** Strip common leading whitespace so template literals look tidy. */
+function dedent(str: string): string {
+  const lines = str.replace(/^\n/, '').replace(/\n\s*$/, '').split('\n');
+  const minIndent = lines
+    .filter((l) => l.trim().length > 0)
+    .reduce((min, l) => {
+      const match = l.match(/^(\s*)/);
+      return match ? Math.min(min, match[1].length) : min;
+    }, Infinity);
+  if (!isFinite(minIndent) || minIndent === 0) return lines.join('\n');
+  return lines.map((l) => l.slice(minIndent)).join('\n');
+}


### PR DESCRIPTION
## Summary
- Add `stories/doc-renderer.ts` — a custom `withDocs()` wrapper that renders inline documentation (rich descriptions + syntax-highlighted, collapsible code snippets) directly in the Storybook Canvas view
- Update all 44 story files (~95+ stories) across every category: Chart Types, Features, Customization, Indicators, Drawings, Navigation, Real-Time, MultiSeries, and TradingView
- Each story now shows what the feature does, how to use it, and the key API calls — making the library self-documenting for new users

## What's included

| Category | Files | Coverage |
|---|---|---|
| Chart Types | 7 | Candlestick, Line, Area, Bar, Baseline, HollowCandle, AllChartTypes |
| Features | 18 | HUD, DrawingTools, PriceLines, Markers, Events, Legend, Volume, Watermark, Screenshot, Periodicity, ExtendedHours, Comparison, ContextMenu, Pagination, InfiniteHistory, ChartState, HeikinAshi, TimeFormatter, etc. |
| Customization | 4 | Themes, Fonts, DualScales, PriceFormatter |
| Indicators | 4 | Moving Averages, Extended (6), Production (6), New (12) |
| Drawings | 1 | 10 drawing tools |
| Navigation | 3 | RangeSwitcher, GoToRealtime, InfiniteHistory |
| Real-Time | 1 | LiveStream, CandleBuilding, LiveLine |
| MultiSeries | 1 | Overlays, Markers, Watermark |
| TradingView | 1 | Full application demo |

## Test plan
- [x] `npx storybook build` completes successfully
- [ ] Visual check: open Storybook and verify doc panels render correctly on Canvas view
- [ ] Verify code blocks are collapsible and syntax-highlighted
- [ ] Confirm existing Docs tab still works (source code + component descriptions preserved)

🤖 Generated with [Claude Code](https://claude.com/claude-code)