### PR TITLE
fix: only initialize MSW during Chromatic testing

### DIFF
--- a/.storybook/preview.ts
+++ b/.storybook/preview.ts
@@ -1,10 +1,21 @@
 import type { Preview } from '@storybook/html';
 import { create } from 'storybook/theming/create';
-import { initialize, mswLoader } from 'msw-storybook-addon';
-import { handlers } from '../stories/mocks/handlers';
+import isChromatic from 'chromatic/isChromatic';
 
-// Initialize MSW with the Yahoo Finance mock handlers
-initialize();
+// Only initialize MSW during Chromatic visual testing — on GitHub Pages
+// the service worker script doesn't exist and blocks all stories from rendering
+let mswLoader: NonNullable<Preview['loaders']>[number] | undefined;
+let mswHandlers: unknown[] | undefined;
+
+if (isChromatic()) {
+  const [mswAddon, mocks] = await Promise.all([
+    import('msw-storybook-addon'),
+    import('../stories/mocks/handlers'),
+  ]);
+  mswAddon.initialize();
+  mswLoader = mswAddon.mswLoader;
+  mswHandlers = mocks.handlers;
+}
 
 const darkTheme = create({
   base: 'dark',
@@ -31,10 +42,8 @@ const preview: Preview = {
     docs: {
       theme: darkTheme,
     },
-    msw: {
-      handlers,
-    },
+    ...(mswHandlers && { msw: { handlers: mswHandlers } }),
   },
-  loaders: [mswLoader],
+  loaders: mswLoader ? [mswLoader] : [],
 };
 export default preview;


### PR DESCRIPTION
## Summary
- MSW service worker registration fails on GitHub Pages (`mockServiceWorker.js` not found at deployed path), blocking all stories from rendering
- Conditionally load MSW (via dynamic `import()`) only when `isChromatic()` returns true
- GitHub Pages Storybook now uses real API data; Chromatic snapshots continue using mocked data

## Test plan
- [ ] Verify Chromatic builds still capture snapshots with mocked data
- [ ] Verify GitHub Pages Storybook loads stories without MSW errors
- [ ] Verify local `storybook dev` works without errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)