### PR TITLE
feat: add CSV, SVG, and PDF export

### DIFF
--- a/src/api/chart-api.ts
+++ b/src/api/chart-api.ts
@@ -52,6 +52,16 @@ import { PointFigureRenderer } from '../renderers/point-figure';
 
 import { isWebGLAvailable, CandlestickWebGLRenderer, LineWebGLRenderer, AreaWebGLRenderer } from '../renderers/webgl/index';
 
+import {
+  exportCSV as exportCSVFn,
+  exportSVG as exportSVGFn,
+  exportPDF as exportPDFFn,
+  type CSVExportOptions,
+  type PDFExportOptions,
+  type SeriesInfo,
+  type IndicatorInfo,
+} from './export';
+
 import type { ISeriesApi } from './series-api';
 import { SeriesApi } from './series-api';
 import type { IPaneApi } from './pane-api';
@@ -240,6 +250,13 @@ export interface IChartApi {
   getMarketSessions(): MarketSession[];
   setSessionFilter(filter: 'regular' | 'extended' | 'all'): void;
   getSessionFilter(): string;
+  // ── Export ────────────────────────────────────────────────────────────────
+  /** Export visible OHLCV data (and optionally indicator values) as a CSV string. */
+  exportCSV(options?: import('./export').CSVExportOptions): string;
+  /** Export the current chart view as an SVG string (PNG image embedded in SVG wrapper). */
+  exportSVG(): string;
+  /** Export the current chart view as a PDF Blob. */
+  exportPDF(options?: import('./export').PDFExportOptions): Blob;
 }
 
 // ─── Internal series entry ──────────────────────────────────────────────────
@@ -1181,6 +1198,44 @@ class ChartApi implements IChartApi {
     ctx.drawImage(this._timeAxisCanvas, Math.round(leftScaleW * pixelRatio), yOffset);
 
     return offscreen;
+  }
+
+  // ── Export ───────────────────────────────────────────────────────────────
+
+  exportCSV(options?: CSVExportOptions): string {
+    const seriesInfos: SeriesInfo[] = this._series
+      .filter((e) => e.api.isVisible())
+      .map((e) => ({
+        label: (e.api.options() as { label?: string }).label ?? '',
+        store: e.api.getDataLayer().store,
+      }));
+
+    const indicatorInfos: IndicatorInfo[] = this._indicators
+      .filter((ind) => ind.isVisible())
+      .map((ind) => {
+        const outputs = new Map<string, Float64Array>();
+        for (const s of ind.internalSeries) {
+          const store = (s as unknown as { getDataLayer(): { store: ColumnStore } }).getDataLayer().store;
+          outputs.set(
+            (s.options() as { label?: string }).label ?? ind.indicatorType(),
+            store.close,
+          );
+        }
+        return { label: ind.indicatorType(), outputs };
+      });
+
+    const range = this._timeScale.visibleRange();
+    return exportCSVFn(seriesInfos, indicatorInfos, range, options);
+  }
+
+  exportSVG(): string {
+    const canvas = this.takeScreenshot();
+    return exportSVGFn(canvas);
+  }
+
+  exportPDF(options?: PDFExportOptions): Blob {
+    const canvas = this.takeScreenshot();
+    return exportPDFFn(canvas, options);
   }
 
   // ── Feature 5: Indicator API ────────────────────────────────────────────

--- a/src/api/export.ts
+++ b/src/api/export.ts
@@ -1,0 +1,332 @@
+import type { ColumnStore, VisibleRange } from '../core/types';
+
+// ─── CSV Export ─────────────────────────────────────────────────────────────
+
+export interface CSVExportOptions {
+  /** Include only bars within this date range (Unix timestamps in seconds). */
+  from?: number;
+  /** Include only bars within this date range (Unix timestamps in seconds). */
+  to?: number;
+  /** Column separator (default: ','). */
+  separator?: string;
+  /** Include indicator columns. */
+  includeIndicators?: boolean;
+}
+
+export interface SeriesInfo {
+  label: string;
+  store: ColumnStore;
+}
+
+export interface IndicatorInfo {
+  label: string;
+  /** Map of output name -> Float64Array values aligned with source series. */
+  outputs: Map<string, Float64Array>;
+}
+
+/**
+ * Export visible OHLCV data as a CSV string.
+ */
+export function exportCSV(
+  series: SeriesInfo[],
+  indicators: IndicatorInfo[],
+  range: VisibleRange | null,
+  options: CSVExportOptions = {},
+): string {
+  const sep = options.separator ?? ',';
+
+  if (series.length === 0) return '';
+
+  // Use the first series as the primary time source
+  const primaryStore = series[0].store;
+  if (primaryStore.length === 0) return '';
+
+  // Determine index range
+  let fromIdx = range?.fromIdx ?? 0;
+  let toIdx = range?.toIdx ?? primaryStore.length - 1;
+  fromIdx = Math.max(0, fromIdx);
+  toIdx = Math.min(primaryStore.length - 1, toIdx);
+
+  // Apply time-based filtering
+  if (options.from !== undefined) {
+    while (fromIdx <= toIdx && primaryStore.time[fromIdx] < options.from) fromIdx++;
+  }
+  if (options.to !== undefined) {
+    while (toIdx >= fromIdx && primaryStore.time[toIdx] > options.to) toIdx--;
+  }
+
+  if (fromIdx > toIdx) return '';
+
+  // Build header
+  const headers: string[] = ['Date', 'Open', 'High', 'Low', 'Close', 'Volume'];
+
+  // Add additional series columns
+  for (let s = 1; s < series.length; s++) {
+    const label = series[s].label || `Series ${s + 1}`;
+    headers.push(`${label} Open`, `${label} High`, `${label} Low`, `${label} Close`);
+  }
+
+  // Add indicator columns
+  if (options.includeIndicators !== false) {
+    for (const ind of indicators) {
+      for (const outputName of ind.outputs.keys()) {
+        headers.push(ind.label ? `${ind.label} ${outputName}` : outputName);
+      }
+    }
+  }
+
+  const rows: string[] = [headers.join(sep)];
+
+  for (let i = fromIdx; i <= toIdx; i++) {
+    const time = primaryStore.time[i];
+    const date = new Date(time * 1000).toISOString();
+    const fields: string[] = [
+      date,
+      String(primaryStore.open[i]),
+      String(primaryStore.high[i]),
+      String(primaryStore.low[i]),
+      String(primaryStore.close[i]),
+      String(primaryStore.volume[i]),
+    ];
+
+    // Additional series
+    for (let s = 1; s < series.length; s++) {
+      const store = series[s].store;
+      if (i < store.length) {
+        fields.push(
+          String(store.open[i]),
+          String(store.high[i]),
+          String(store.low[i]),
+          String(store.close[i]),
+        );
+      } else {
+        fields.push('', '', '', '');
+      }
+    }
+
+    // Indicators
+    if (options.includeIndicators !== false) {
+      for (const ind of indicators) {
+        for (const values of ind.outputs.values()) {
+          const val = i < values.length ? values[i] : NaN;
+          fields.push(isNaN(val) ? '' : String(val));
+        }
+      }
+    }
+
+    rows.push(fields.join(sep));
+  }
+
+  return rows.join('\n');
+}
+
+// ─── SVG Export ─────────────────────────────────────────────────────────────
+
+/**
+ * Generate an SVG string from a screenshot canvas.
+ * The canvas pixel data is embedded as a base64 PNG <image> element within
+ * an SVG wrapper, preserving the exact chart appearance including themes
+ * and annotations.
+ */
+export function exportSVG(screenshotCanvas: HTMLCanvasElement): string {
+  const w = screenshotCanvas.width;
+  const h = screenshotCanvas.height;
+  const dataURL = screenshotCanvas.toDataURL('image/png');
+
+  return [
+    `<?xml version="1.0" encoding="UTF-8"?>`,
+    `<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="${w}" height="${h}" viewBox="0 0 ${w} ${h}">`,
+    `  <image width="${w}" height="${h}" xlink:href="${dataURL}" />`,
+    `</svg>`,
+  ].join('\n');
+}
+
+// ─── PDF Export ─────────────────────────────────────────────────────────────
+
+export interface PDFExportOptions {
+  /** Paper size (default: 'letter'). */
+  pageSize?: 'letter' | 'a4';
+  /** Page orientation (default: 'landscape'). */
+  orientation?: 'portrait' | 'landscape';
+  /** Optional title text at top of page. */
+  title?: string;
+}
+
+// PDF page dimensions in points (1 point = 1/72 inch)
+const PAGE_SIZES = {
+  letter: { width: 612, height: 792 },
+  a4: { width: 595.28, height: 841.89 },
+};
+
+/**
+ * Generate a minimal PDF document containing the chart image.
+ *
+ * Uses a minimal PDF 1.4 generator (no external dependencies) that embeds
+ * the chart as a JPEG image stream.
+ */
+export function exportPDF(
+  screenshotCanvas: HTMLCanvasElement,
+  options: PDFExportOptions = {},
+): Blob {
+  const pageSize = PAGE_SIZES[options.pageSize ?? 'letter'];
+  const isLandscape = (options.orientation ?? 'landscape') === 'landscape';
+  const pageW = isLandscape ? pageSize.height : pageSize.width;
+  const pageH = isLandscape ? pageSize.width : pageSize.height;
+
+  // Get image data as JPEG
+  const dataURL = screenshotCanvas.toDataURL('image/jpeg', 0.95);
+  const base64 = dataURL.split(',')[1];
+  const binaryStr = atob(base64);
+  const imageBytes = new Uint8Array(binaryStr.length);
+  for (let i = 0; i < binaryStr.length; i++) {
+    imageBytes[i] = binaryStr.charCodeAt(i);
+  }
+
+  // Compute image placement (fit to page with margins)
+  const margin = 36; // 0.5 inch
+  const titleHeight = options.title ? 24 : 0;
+  const availW = pageW - 2 * margin;
+  const availH = pageH - 2 * margin - titleHeight;
+  const imgAspect = screenshotCanvas.width / screenshotCanvas.height;
+  const areaAspect = availW / availH;
+
+  let imgW: number, imgH: number;
+  if (imgAspect > areaAspect) {
+    imgW = availW;
+    imgH = availW / imgAspect;
+  } else {
+    imgH = availH;
+    imgW = availH * imgAspect;
+  }
+
+  const imgX = margin + (availW - imgW) / 2;
+  const imgY = margin + (availH - imgH) / 2;
+
+  // Build minimal PDF
+  const objects: string[] = [];
+  const offsets: number[] = [];
+  let currentOffset = 0;
+
+  function addObject(content: string, stream?: Uint8Array): number {
+    const id = objects.length + 1;
+    let obj: string;
+    if (stream) {
+      obj = `${id} 0 obj\n${content}\nendobj\n`;
+    } else {
+      obj = `${id} 0 obj\n${content}\nendobj\n`;
+    }
+    offsets.push(currentOffset);
+    objects.push(obj);
+    currentOffset += new TextEncoder().encode(obj).length;
+    if (stream) {
+      currentOffset += stream.length + 1; // +1 for newline before endstream
+    }
+    return id;
+  }
+
+  // Object 1: Catalog
+  const catalogId = addObject('<< /Type /Catalog /Pages 2 0 R >>');
+
+  // Object 2: Pages
+  const pagesId = addObject(`<< /Type /Pages /Kids [3 0 R] /Count 1 >>`);
+
+  // Object 3: Page
+  const pageId = addObject(
+    `<< /Type /Page /Parent ${pagesId} 0 R /MediaBox [0 0 ${pageW} ${pageH}] /Contents 5 0 R /Resources << /XObject << /Img 4 0 R >> /Font << /F1 6 0 R >> >> >>`,
+  );
+
+  // Object 4: Image XObject (placeholder - we'll handle inline)
+  const imageStreamHeader = `<< /Type /XObject /Subtype /Image /Width ${screenshotCanvas.width} /Height ${screenshotCanvas.height} /ColorSpace /DeviceRGB /BitsPerComponent 8 /Filter /DCTDecode /Length ${imageBytes.length} >>`;
+  addObject(imageStreamHeader);
+
+  // Object 5: Page content stream
+  let contentStr = '';
+  if (options.title) {
+    const titleY = pageH - margin - 14;
+    contentStr += `BT /F1 14 Tf ${margin} ${titleY} Td (${escapePDFString(options.title)}) Tj ET\n`;
+  }
+  contentStr += `q ${imgW} 0 0 ${imgH} ${imgX} ${imgY} cm /Img Do Q\n`;
+  const contentBytes = new TextEncoder().encode(contentStr);
+  addObject(`<< /Length ${contentBytes.length} >>`);
+
+  // Object 6: Font
+  addObject('<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>');
+
+  // Now build the final PDF manually with binary streams
+  const header = '%PDF-1.4\n%\xE2\xE3\xCF\xD3\n';
+  const parts: (string | Uint8Array)[] = [header];
+
+  // Re-calculate offsets properly
+  const realOffsets: number[] = [];
+  let pos = new TextEncoder().encode(header).length;
+
+  // Object 1: Catalog
+  const obj1 = `1 0 obj\n<< /Type /Catalog /Pages 2 0 R >>\nendobj\n`;
+  realOffsets.push(pos);
+  parts.push(obj1);
+  pos += new TextEncoder().encode(obj1).length;
+
+  // Object 2: Pages
+  const obj2 = `2 0 obj\n<< /Type /Pages /Kids [3 0 R] /Count 1 >>\nendobj\n`;
+  realOffsets.push(pos);
+  parts.push(obj2);
+  pos += new TextEncoder().encode(obj2).length;
+
+  // Object 3: Page
+  const obj3 = `3 0 obj\n<< /Type /Page /Parent 2 0 R /MediaBox [0 0 ${pageW} ${pageH}] /Contents 5 0 R /Resources << /XObject << /Img 4 0 R >> /Font << /F1 6 0 R >> >> >>\nendobj\n`;
+  realOffsets.push(pos);
+  parts.push(obj3);
+  pos += new TextEncoder().encode(obj3).length;
+
+  // Object 4: Image
+  const imgHeader = `4 0 obj\n<< /Type /XObject /Subtype /Image /Width ${screenshotCanvas.width} /Height ${screenshotCanvas.height} /ColorSpace /DeviceRGB /BitsPerComponent 8 /Filter /DCTDecode /Length ${imageBytes.length} >>\nstream\n`;
+  const imgFooter = `\nendstream\nendobj\n`;
+  realOffsets.push(pos);
+  parts.push(imgHeader);
+  pos += new TextEncoder().encode(imgHeader).length;
+  parts.push(imageBytes);
+  pos += imageBytes.length;
+  parts.push(imgFooter);
+  pos += new TextEncoder().encode(imgFooter).length;
+
+  // Object 5: Content stream
+  const obj5Header = `5 0 obj\n<< /Length ${contentBytes.length} >>\nstream\n`;
+  const obj5Footer = `\nendstream\nendobj\n`;
+  realOffsets.push(pos);
+  parts.push(obj5Header);
+  pos += new TextEncoder().encode(obj5Header).length;
+  parts.push(contentBytes);
+  pos += contentBytes.length;
+  parts.push(obj5Footer);
+  pos += new TextEncoder().encode(obj5Footer).length;
+
+  // Object 6: Font
+  const obj6 = `6 0 obj\n<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>\nendobj\n`;
+  realOffsets.push(pos);
+  parts.push(obj6);
+  pos += new TextEncoder().encode(obj6).length;
+
+  // Cross-reference table
+  const xrefStart = pos;
+  const xref = [
+    'xref',
+    `0 ${realOffsets.length + 1}`,
+    '0000000000 65535 f ',
+    ...realOffsets.map((off) => `${String(off).padStart(10, '0')} 00000 n `),
+  ].join('\n') + '\n';
+  parts.push(xref);
+
+  // Trailer
+  const trailer = `trailer\n<< /Size ${realOffsets.length + 1} /Root 1 0 R >>\nstartxref\n${xrefStart}\n%%EOF\n`;
+  parts.push(trailer);
+
+  // Combine into Blob
+  const blobParts: BlobPart[] = parts.map((p) =>
+    typeof p === 'string' ? new TextEncoder().encode(p).buffer as ArrayBuffer : p.buffer as ArrayBuffer,
+  );
+  return new Blob(blobParts, { type: 'application/pdf' });
+}
+
+function escapePDFString(str: string): string {
+  return str.replace(/\\/g, '\\\\').replace(/\(/g, '\\(').replace(/\)/g, '\\)');
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -25,6 +25,9 @@ export type { RendererType } from './api/options';
 // ─── WebGL ──────────────────────────────────────────────────────────
 export { isWebGLAvailable } from './renderers/webgl/index';
 
+// ─── Export ─────────────────────────────────────────────────────────
+export type { CSVExportOptions, PDFExportOptions } from './api/export';
+
 // ─── Periodicity ──────────────────────────────────────────────────────
 export type { Periodicity } from './core/periodicity';
 export { periodicityToSeconds, periodicityToLabel } from './core/periodicity';

--- a/tests/api/export.test.ts
+++ b/tests/api/export.test.ts
@@ -1,0 +1,171 @@
+import { describe, it, expect, vi } from 'vitest';
+import { exportCSV, exportSVG, exportPDF } from '@/api/export';
+import type { ColumnStore, VisibleRange } from '@/core/types';
+import type { SeriesInfo, IndicatorInfo } from '@/api/export';
+
+function makeStore(length: number, baseTime = 1609459200): ColumnStore {
+  const time = new Float64Array(length);
+  const open = new Float64Array(length);
+  const high = new Float64Array(length);
+  const low = new Float64Array(length);
+  const close = new Float64Array(length);
+  const volume = new Float64Array(length);
+  for (let i = 0; i < length; i++) {
+    time[i] = baseTime + i * 86400;
+    open[i] = 100 + i;
+    high[i] = 110 + i;
+    low[i] = 90 + i;
+    close[i] = 105 + i;
+    volume[i] = 1000 * (i + 1);
+  }
+  return { time, open, high, low, close, volume, length };
+}
+
+// ─── CSV Export ───────────────────────────────────────────────────────────────
+
+describe('exportCSV', () => {
+  it('exports OHLCV data with ISO date header', () => {
+    const store = makeStore(3);
+    const series: SeriesInfo[] = [{ label: 'AAPL', store }];
+    const csv = exportCSV(series, [], { fromIdx: 0, toIdx: 2 });
+
+    const lines = csv.split('\n');
+    expect(lines.length).toBe(4); // header + 3 rows
+    expect(lines[0]).toBe('Date,Open,High,Low,Close,Volume');
+
+    const row1 = lines[1].split(',');
+    expect(row1[0]).toContain('2021-01-01'); // baseTime = 2021-01-01
+    expect(row1[1]).toBe('100');
+    expect(row1[2]).toBe('110');
+    expect(row1[3]).toBe('90');
+    expect(row1[4]).toBe('105');
+    expect(row1[5]).toBe('1000');
+  });
+
+  it('respects from/to time filters', () => {
+    const store = makeStore(10);
+    const series: SeriesInfo[] = [{ label: 'TEST', store }];
+    const from = store.time[2];
+    const to = store.time[5];
+    const csv = exportCSV(series, [], { fromIdx: 0, toIdx: 9 }, { from, to });
+
+    const lines = csv.split('\n');
+    expect(lines.length).toBe(5); // header + 4 rows [2..5]
+  });
+
+  it('uses custom separator', () => {
+    const store = makeStore(2);
+    const series: SeriesInfo[] = [{ label: '', store }];
+    const csv = exportCSV(series, [], { fromIdx: 0, toIdx: 1 }, { separator: '\t' });
+
+    const lines = csv.split('\n');
+    expect(lines[0]).toContain('\t');
+    expect(lines[0].split('\t').length).toBe(6);
+  });
+
+  it('includes indicator columns', () => {
+    const store = makeStore(3);
+    const series: SeriesInfo[] = [{ label: 'SPY', store }];
+    const smaValues = new Float64Array([NaN, 102.5, 103.5]);
+    const indicators: IndicatorInfo[] = [
+      { label: 'SMA', outputs: new Map([['SMA', smaValues]]) },
+    ];
+    const csv = exportCSV(series, indicators, { fromIdx: 0, toIdx: 2 });
+
+    const lines = csv.split('\n');
+    expect(lines[0]).toContain('SMA SMA');
+    // First row: NaN → empty
+    expect(lines[1].split(',').pop()).toBe('');
+    // Second row: has value
+    expect(lines[2].split(',').pop()).toBe('102.5');
+  });
+
+  it('returns empty string for empty series', () => {
+    expect(exportCSV([], [], null)).toBe('');
+  });
+
+  it('returns empty string for empty store', () => {
+    const store = makeStore(0);
+    expect(exportCSV([{ label: '', store }], [], null)).toBe('');
+  });
+
+  it('includes multiple series columns', () => {
+    const store1 = makeStore(3);
+    const store2 = makeStore(3, 1609459200);
+    const series: SeriesInfo[] = [
+      { label: 'AAPL', store: store1 },
+      { label: 'GOOG', store: store2 },
+    ];
+    const csv = exportCSV(series, [], { fromIdx: 0, toIdx: 2 });
+    const header = csv.split('\n')[0];
+    expect(header).toContain('GOOG Open');
+    expect(header).toContain('GOOG Close');
+  });
+
+  it('handles null range (uses full store)', () => {
+    const store = makeStore(5);
+    const csv = exportCSV([{ label: '', store }], [], null);
+    const lines = csv.split('\n');
+    expect(lines.length).toBe(6); // header + 5 rows
+  });
+});
+
+// ─── SVG Export ───────────────────────────────────────────────────────────────
+
+describe('exportSVG', () => {
+  it('generates valid SVG with embedded image', () => {
+    const canvas = document.createElement('canvas');
+    canvas.width = 800;
+    canvas.height = 400;
+    const svg = exportSVG(canvas);
+
+    expect(svg).toContain('<?xml version="1.0"');
+    expect(svg).toContain('<svg xmlns="http://www.w3.org/2000/svg"');
+    expect(svg).toContain('width="800"');
+    expect(svg).toContain('height="400"');
+    expect(svg).toContain('<image');
+    expect(svg).toContain('</svg>');
+  });
+});
+
+// ─── PDF Export ───────────────────────────────────────────────────────────────
+
+describe('exportPDF', () => {
+  // jsdom doesn't support toDataURL with actual image data, so mock it
+  function mockCanvas(): HTMLCanvasElement {
+    const canvas = document.createElement('canvas');
+    canvas.width = 800;
+    canvas.height = 400;
+    // Mock toDataURL to return a minimal valid JPEG base64
+    vi.spyOn(canvas, 'toDataURL').mockReturnValue(
+      'data:image/jpeg;base64,/9j/4AAQSkZJRg==',
+    );
+    return canvas;
+  }
+
+  it('returns a Blob with PDF content type', () => {
+    const canvas = mockCanvas();
+    const blob = exportPDF(canvas);
+    expect(blob).toBeInstanceOf(Blob);
+    expect(blob.type).toBe('application/pdf');
+    expect(blob.size).toBeGreaterThan(0);
+  });
+
+  it('uses landscape letter by default', () => {
+    const canvas = mockCanvas();
+    const blob = exportPDF(canvas);
+    expect(blob.size).toBeGreaterThan(100);
+  });
+
+  it('accepts page size and orientation options', () => {
+    const canvas = mockCanvas();
+    const blob = exportPDF(canvas, { pageSize: 'a4', orientation: 'portrait' });
+    expect(blob.size).toBeGreaterThan(100);
+  });
+
+  it('includes title when provided', () => {
+    const canvas = mockCanvas();
+    const blob = exportPDF(canvas, { title: 'Test Chart' });
+    expect(blob.size).toBeGreaterThan(100);
+  });
+});


### PR DESCRIPTION
## Summary

- Add `chart.exportCSV(options?)` — exports visible OHLCV data with indicator values, date range filtering, custom separators
- Add `chart.exportSVG()` — generates SVG string with embedded PNG chart image
- Add `chart.exportPDF(options?)` — generates PDF Blob with zero dependencies (letter/a4, portrait/landscape, optional title)

Closes #24

## Test plan

- [x] 13 new unit tests covering CSV formatting, filtering, indicators, SVG structure, PDF blob generation
- [x] All 1213 tests pass
- [x] TypeScript compiles clean
- [x] Build succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)