### PR TITLE
feat: add range selection tool and measure tool

### DIFF
--- a/src/api/chart-api.ts
+++ b/src/api/chart-api.ts
@@ -17,6 +17,12 @@ import { type ChartState, CHART_STATE_VERSION, validateChartState } from '../cor
 import { Pane } from '../core/pane';
 import { PaneDivider, DIVIDER_HEIGHT } from '../core/pane-divider';
 import { AlertLine, type AlertLineOptions } from '../core/alert-line';
+import {
+  RangeSelectionHandler,
+  MeasureHandler,
+  type RangeSelectionCallback,
+  type MeasureCallback,
+} from '../interactions/range-selection';
 import { EventRouter } from '../interactions/event-router';
 import { PanZoomHandler } from '../interactions/pan-zoom';
 import { CrosshairHandler } from '../interactions/crosshair';
@@ -259,6 +265,20 @@ export interface IChartApi {
   /** Export the current chart view as a PDF Blob. */
   exportPDF(options?: import('./export').PDFExportOptions): Blob;
   // ── Alert Lines ──────────────────────────────────────────────────────────
+  // ── Range Selection & Measure ─────────────────────────────────────────
+  /** Activate the range selection mode (drag to highlight a time range). */
+  setRangeSelectionActive(active: boolean): void;
+  /** Subscribe to range selection results. */
+  onRangeSelected(callback: import('../interactions/range-selection').RangeSelectionCallback): void;
+  /** Unsubscribe from range selection results. */
+  offRangeSelected(callback: import('../interactions/range-selection').RangeSelectionCallback): void;
+  /** Activate the measure tool (click two points to see stats). */
+  setMeasureActive(active: boolean): void;
+  /** Subscribe to measure results. */
+  onMeasure(callback: import('../interactions/range-selection').MeasureCallback): void;
+  /** Unsubscribe from measure results. */
+  offMeasure(callback: import('../interactions/range-selection').MeasureCallback): void;
+  // ── Alert Lines ──────────────────────────────────────────────────────────
   /** Add an alert line at the given price level. */
   addAlertLine(price: number, options?: Partial<import('../core/alert-line').AlertLineOptions>): import('../core/alert-line').AlertLine;
   /** Remove an alert line. */
@@ -419,6 +439,10 @@ class ChartApi implements IChartApi {
   private _drawingApis: Map<string, DrawingApiImpl> = new Map();
   private _drawingHandler: DrawingHandler | null = null;
   private _nextDrawingId = 0;
+
+  // Range selection & measure handlers
+  private _rangeSelectionHandler: RangeSelectionHandler | null = null;
+  private _measureHandler: MeasureHandler | null = null;
 
   // Alert lines
   private _alertLines: AlertLine[] = [];
@@ -1248,6 +1272,64 @@ class ChartApi implements IChartApi {
   exportPDF(options?: PDFExportOptions): Blob {
     const canvas = this.takeScreenshot();
     return exportPDFFn(canvas, options);
+  }
+
+  // ── Range Selection & Measure ─────────────────────────────────────────
+
+  private _ensureRangeSelectionHandler(): RangeSelectionHandler {
+    if (!this._rangeSelectionHandler) {
+      this._rangeSelectionHandler = new RangeSelectionHandler(
+        this._timeScale,
+        this._mainPane.priceScale,
+        () => this._series.length > 0 ? this._series[0].api.getDataLayer().store : null,
+        () => this.requestRepaint(InvalidationLevel.Light),
+      );
+      this._eventRouter.addHandler(this._rangeSelectionHandler);
+    }
+    return this._rangeSelectionHandler;
+  }
+
+  private _ensureMeasureHandler(): MeasureHandler {
+    if (!this._measureHandler) {
+      this._measureHandler = new MeasureHandler(
+        this._timeScale,
+        this._mainPane.priceScale,
+        () => this._series.length > 0 ? this._series[0].api.getDataLayer().store : null,
+        () => this.requestRepaint(InvalidationLevel.Light),
+      );
+      this._eventRouter.addHandler(this._measureHandler);
+    }
+    return this._measureHandler;
+  }
+
+  setRangeSelectionActive(active: boolean): void {
+    const handler = this._ensureRangeSelectionHandler();
+    handler.active = active;
+    // Deactivate measure when range selection is active
+    if (active && this._measureHandler) this._measureHandler.active = false;
+  }
+
+  onRangeSelected(callback: RangeSelectionCallback): void {
+    this._ensureRangeSelectionHandler().onRangeSelected(callback);
+  }
+
+  offRangeSelected(callback: RangeSelectionCallback): void {
+    this._rangeSelectionHandler?.offRangeSelected(callback);
+  }
+
+  setMeasureActive(active: boolean): void {
+    const handler = this._ensureMeasureHandler();
+    handler.active = active;
+    // Deactivate range selection when measure is active
+    if (active && this._rangeSelectionHandler) this._rangeSelectionHandler.active = false;
+  }
+
+  onMeasure(callback: MeasureCallback): void {
+    this._ensureMeasureHandler().onMeasure(callback);
+  }
+
+  offMeasure(callback: MeasureCallback): void {
+    this._measureHandler?.offMeasure(callback);
   }
 
   // ── Alert Lines ─────────────────────────────────────────────────────────
@@ -2500,6 +2582,54 @@ class ChartApi implements IChartApi {
           const renderer = view.renderer();
           renderer?.draw(target);
         }
+      }
+    }
+
+    // Range selection overlay (main pane only)
+    if (isMain && this._rangeSelectionHandler?.selecting) {
+      const rsh = this._rangeSelectionHandler;
+      const sx = Math.round(Math.min(rsh.startX, rsh.endX) * pixelRatio);
+      const ex = Math.round(Math.max(rsh.startX, rsh.endX) * pixelRatio);
+      const selW = ex - sx;
+      ctx.save();
+      ctx.fillStyle = 'rgba(33, 150, 243, 0.15)';
+      ctx.fillRect(sx, 0, selW, Math.round(chartH * pixelRatio));
+      ctx.strokeStyle = 'rgba(33, 150, 243, 0.6)';
+      ctx.lineWidth = pixelRatio;
+      ctx.setLineDash([]);
+      ctx.strokeRect(sx, 0, selW, Math.round(chartH * pixelRatio));
+      ctx.restore();
+    }
+
+    // Measure tool overlay (main pane only)
+    if (isMain && this._measureHandler?.firstPoint) {
+      const mh = this._measureHandler;
+      const p1 = mh.firstPoint!;
+      const p2 = mh.secondPoint ?? (mh.hovering ? { x: mh.hoverX, y: mh.hoverY } : null);
+      if (p2) {
+        const x1 = Math.round(p1.x * pixelRatio);
+        const y1 = Math.round(p1.y * pixelRatio);
+        const x2 = Math.round(p2.x * pixelRatio);
+        const y2 = Math.round(p2.y * pixelRatio);
+        ctx.save();
+        ctx.strokeStyle = '#FF9800';
+        ctx.lineWidth = pixelRatio;
+        ctx.setLineDash([6 * pixelRatio, 4 * pixelRatio]);
+        ctx.beginPath();
+        ctx.moveTo(x1, y1);
+        ctx.lineTo(x2, y2);
+        ctx.stroke();
+        ctx.setLineDash([]);
+        // Draw endpoint dots
+        ctx.fillStyle = '#FF9800';
+        const dotR = 3 * pixelRatio;
+        ctx.beginPath();
+        ctx.arc(x1, y1, dotR, 0, Math.PI * 2);
+        ctx.fill();
+        ctx.beginPath();
+        ctx.arc(x2, y2, dotR, 0, Math.PI * 2);
+        ctx.fill();
+        ctx.restore();
       }
     }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -54,6 +54,14 @@ export type {
 export { PriceLine } from './core/price-line';
 export type { PriceLineOptions } from './core/price-line';
 
+// ─── Range Selection & Measure ───────────────────────────────────────
+export type {
+  RangeSelectionStats,
+  RangeSelectionCallback,
+  MeasureResult,
+  MeasureCallback,
+} from './interactions/range-selection';
+
 // ─── Alert lines ──────────────────────────────────────────────────────
 export { AlertLine } from './core/alert-line';
 export type { AlertLineOptions, AlertTriggerMode, AlertLineCallback } from './core/alert-line';

--- a/src/interactions/range-selection.ts
+++ b/src/interactions/range-selection.ts
@@ -1,0 +1,300 @@
+import type { EventHandler } from './event-router';
+import type { TimeScale } from '../core/time-scale';
+import type { PriceScale } from '../core/price-scale';
+import type { ColumnStore } from '../core/types';
+
+export interface RangeSelectionStats {
+  fromTime: number;
+  toTime: number;
+  fromPrice: number;
+  toPrice: number;
+  high: number;
+  low: number;
+  priceChange: number;
+  percentChange: number;
+  barCount: number;
+  totalVolume: number;
+}
+
+export type RangeSelectionCallback = (stats: RangeSelectionStats | null) => void;
+
+/**
+ * RangeSelectionHandler — allows users to drag-select a time range on the
+ * chart and see summary statistics (high, low, change, volume).
+ *
+ * Activated by setting `active = true`. When active, pointer-down starts a
+ * selection; pointer-move extends it; pointer-up finalizes and fires the
+ * callback.
+ */
+export class RangeSelectionHandler implements EventHandler {
+  private _active = false;
+  private _selecting = false;
+  private _startX = 0;
+  private _startY = 0;
+  private _endX = 0;
+  private _endY = 0;
+  private _timeScale: TimeScale;
+  private _priceScale: PriceScale;
+  private _getStore: () => ColumnStore | null;
+  private _requestRepaint: () => void;
+  private _callbacks: RangeSelectionCallback[] = [];
+
+  constructor(
+    timeScale: TimeScale,
+    priceScale: PriceScale,
+    getStore: () => ColumnStore | null,
+    requestRepaint: () => void,
+  ) {
+    this._timeScale = timeScale;
+    this._priceScale = priceScale;
+    this._getStore = getStore;
+    this._requestRepaint = requestRepaint;
+  }
+
+  get active(): boolean { return this._active; }
+  set active(value: boolean) {
+    this._active = value;
+    if (!value) this.clear();
+  }
+
+  get selecting(): boolean { return this._selecting; }
+  get startX(): number { return this._startX; }
+  get startY(): number { return this._startY; }
+  get endX(): number { return this._endX; }
+  get endY(): number { return this._endY; }
+
+  onRangeSelected(callback: RangeSelectionCallback): void {
+    this._callbacks.push(callback);
+  }
+
+  offRangeSelected(callback: RangeSelectionCallback): void {
+    const idx = this._callbacks.indexOf(callback);
+    if (idx >= 0) this._callbacks.splice(idx, 1);
+  }
+
+  clear(): void {
+    this._selecting = false;
+    this._requestRepaint();
+    for (const cb of this._callbacks) cb(null);
+  }
+
+  onPointerDown(x: number, y: number): boolean | void {
+    if (!this._active) return;
+    this._selecting = true;
+    this._startX = x;
+    this._startY = y;
+    this._endX = x;
+    this._endY = y;
+    this._requestRepaint();
+    return true;
+  }
+
+  onPointerMove(x: number, y: number): boolean | void {
+    if (!this._selecting) return;
+    this._endX = x;
+    this._endY = y;
+    this._requestRepaint();
+    return true;
+  }
+
+  onPointerUp(): boolean | void {
+    if (!this._selecting) return;
+    this._selecting = false;
+
+    const stats = this._computeStats();
+    if (stats) {
+      for (const cb of this._callbacks) cb(stats);
+    }
+  }
+
+  onKeyDown(key: string): boolean | void {
+    if (key === 'Escape' && this._selecting) {
+      this.clear();
+      return true;
+    }
+  }
+
+  private _computeStats(): RangeSelectionStats | null {
+    const store = this._getStore();
+    if (!store || store.length === 0) return null;
+
+    // Convert pixel X to bar index
+    let fromIdx = Math.round(this._timeScale.xToIndex(Math.min(this._startX, this._endX)));
+    let toIdx = Math.round(this._timeScale.xToIndex(Math.max(this._startX, this._endX)));
+    fromIdx = Math.max(0, Math.min(store.length - 1, fromIdx));
+    toIdx = Math.max(0, Math.min(store.length - 1, toIdx));
+
+    if (fromIdx > toIdx) [fromIdx, toIdx] = [toIdx, fromIdx];
+    if (fromIdx === toIdx) return null;
+
+    let high = -Infinity;
+    let low = Infinity;
+    let totalVolume = 0;
+
+    for (let i = fromIdx; i <= toIdx; i++) {
+      if (store.high[i] > high) high = store.high[i];
+      if (store.low[i] < low) low = store.low[i];
+      totalVolume += store.volume[i];
+    }
+
+    const fromPrice = store.close[fromIdx];
+    const toPrice = store.close[toIdx];
+    const priceChange = toPrice - fromPrice;
+    const percentChange = fromPrice !== 0 ? (priceChange / fromPrice) * 100 : 0;
+
+    return {
+      fromTime: store.time[fromIdx],
+      toTime: store.time[toIdx],
+      fromPrice,
+      toPrice,
+      high,
+      low,
+      priceChange,
+      percentChange,
+      barCount: toIdx - fromIdx + 1,
+      totalVolume,
+    };
+  }
+}
+
+// ─── Measure Tool ───────────────────────────────────────────────────────────
+
+export interface MeasureResult {
+  fromTime: number;
+  toTime: number;
+  fromPrice: number;
+  toPrice: number;
+  priceChange: number;
+  percentChange: number;
+  barCount: number;
+  timeElapsed: number;
+}
+
+export type MeasureCallback = (result: MeasureResult | null) => void;
+
+/**
+ * MeasureHandler — click two points to see price change, % change, bar count,
+ * and time elapsed between them.
+ */
+export class MeasureHandler implements EventHandler {
+  private _active = false;
+  private _firstPoint: { x: number; y: number } | null = null;
+  private _secondPoint: { x: number; y: number } | null = null;
+  private _hovering = false;
+  private _hoverX = 0;
+  private _hoverY = 0;
+  private _timeScale: TimeScale;
+  private _priceScale: PriceScale;
+  private _getStore: () => ColumnStore | null;
+  private _requestRepaint: () => void;
+  private _callbacks: MeasureCallback[] = [];
+
+  constructor(
+    timeScale: TimeScale,
+    priceScale: PriceScale,
+    getStore: () => ColumnStore | null,
+    requestRepaint: () => void,
+  ) {
+    this._timeScale = timeScale;
+    this._priceScale = priceScale;
+    this._getStore = getStore;
+    this._requestRepaint = requestRepaint;
+  }
+
+  get active(): boolean { return this._active; }
+  set active(value: boolean) {
+    this._active = value;
+    if (!value) this.clear();
+  }
+
+  get firstPoint(): { x: number; y: number } | null { return this._firstPoint; }
+  get secondPoint(): { x: number; y: number } | null { return this._secondPoint; }
+  get hovering(): boolean { return this._hovering; }
+  get hoverX(): number { return this._hoverX; }
+  get hoverY(): number { return this._hoverY; }
+
+  onMeasure(callback: MeasureCallback): void {
+    this._callbacks.push(callback);
+  }
+
+  offMeasure(callback: MeasureCallback): void {
+    const idx = this._callbacks.indexOf(callback);
+    if (idx >= 0) this._callbacks.splice(idx, 1);
+  }
+
+  clear(): void {
+    this._firstPoint = null;
+    this._secondPoint = null;
+    this._hovering = false;
+    this._requestRepaint();
+    for (const cb of this._callbacks) cb(null);
+  }
+
+  onPointerDown(x: number, y: number): boolean | void {
+    if (!this._active) return;
+
+    if (!this._firstPoint) {
+      this._firstPoint = { x, y };
+      this._secondPoint = null;
+      this._requestRepaint();
+      return true;
+    }
+
+    // Second click — compute result
+    this._secondPoint = { x, y };
+    this._hovering = false;
+    this._requestRepaint();
+
+    const result = this._computeResult();
+    if (result) {
+      for (const cb of this._callbacks) cb(result);
+    }
+    return true;
+  }
+
+  onPointerMove(x: number, y: number): boolean | void {
+    if (!this._active || !this._firstPoint || this._secondPoint) return;
+    this._hovering = true;
+    this._hoverX = x;
+    this._hoverY = y;
+    this._requestRepaint();
+    return true;
+  }
+
+  onKeyDown(key: string): boolean | void {
+    if (key === 'Escape' && this._active) {
+      this.clear();
+      return true;
+    }
+  }
+
+  private _computeResult(): MeasureResult | null {
+    if (!this._firstPoint || !this._secondPoint) return null;
+    const store = this._getStore();
+    if (!store || store.length === 0) return null;
+
+    const idx1 = Math.max(0, Math.min(store.length - 1,
+      Math.round(this._timeScale.xToIndex(this._firstPoint.x))));
+    const idx2 = Math.max(0, Math.min(store.length - 1,
+      Math.round(this._timeScale.xToIndex(this._secondPoint.x))));
+
+    const fromIdx = Math.min(idx1, idx2);
+    const toIdx = Math.max(idx1, idx2);
+
+    const fromPrice = this._priceScale.yToPrice(this._firstPoint.y);
+    const toPrice = this._priceScale.yToPrice(this._secondPoint.y);
+    const priceChange = toPrice - fromPrice;
+    const percentChange = fromPrice !== 0 ? (priceChange / fromPrice) * 100 : 0;
+
+    return {
+      fromTime: store.time[fromIdx],
+      toTime: store.time[toIdx],
+      fromPrice,
+      toPrice,
+      priceChange,
+      percentChange,
+      barCount: toIdx - fromIdx + 1,
+      timeElapsed: store.time[toIdx] - store.time[fromIdx],
+    };
+  }
+}

--- a/tests/interactions/range-selection.test.ts
+++ b/tests/interactions/range-selection.test.ts
@@ -1,0 +1,271 @@
+import { describe, it, expect, vi } from 'vitest';
+import { RangeSelectionHandler, MeasureHandler } from '@/interactions/range-selection';
+import type { ColumnStore } from '@/core/types';
+
+function makeStore(length: number): ColumnStore {
+  const time = new Float64Array(length);
+  const open = new Float64Array(length);
+  const high = new Float64Array(length);
+  const low = new Float64Array(length);
+  const close = new Float64Array(length);
+  const volume = new Float64Array(length);
+  for (let i = 0; i < length; i++) {
+    time[i] = 1609459200 + i * 86400;
+    open[i] = 100 + i;
+    high[i] = 110 + i;
+    low[i] = 90 + i;
+    close[i] = 105 + i;
+    volume[i] = 1000 * (i + 1);
+  }
+  return { time, open, high, low, close, volume, length };
+}
+
+function makeTimeScale() {
+  return {
+    xToIndex: vi.fn((x: number) => Math.round(x / 10)),
+    indexToX: vi.fn((i: number) => i * 10),
+  };
+}
+
+function makePriceScale() {
+  return {
+    priceToY: vi.fn((p: number) => 400 - p),
+    yToPrice: vi.fn((y: number) => 400 - y),
+  };
+}
+
+// ─── RangeSelectionHandler ────────────────────────────────────────────────
+
+describe('RangeSelectionHandler', () => {
+  it('starts inactive', () => {
+    const store = makeStore(10);
+    const handler = new RangeSelectionHandler(
+      makeTimeScale() as never,
+      makePriceScale() as never,
+      () => store,
+      vi.fn(),
+    );
+    expect(handler.active).toBe(false);
+    expect(handler.selecting).toBe(false);
+  });
+
+  it('ignores pointer events when inactive', () => {
+    const store = makeStore(10);
+    const repaint = vi.fn();
+    const handler = new RangeSelectionHandler(
+      makeTimeScale() as never,
+      makePriceScale() as never,
+      () => store,
+      repaint,
+    );
+    expect(handler.onPointerDown(10, 10, 0)).toBeUndefined();
+    expect(handler.selecting).toBe(false);
+  });
+
+  it('starts selection on pointer down when active', () => {
+    const store = makeStore(10);
+    const repaint = vi.fn();
+    const handler = new RangeSelectionHandler(
+      makeTimeScale() as never,
+      makePriceScale() as never,
+      () => store,
+      repaint,
+    );
+    handler.active = true;
+    const consumed = handler.onPointerDown(20, 50, 0);
+    expect(consumed).toBe(true);
+    expect(handler.selecting).toBe(true);
+    expect(handler.startX).toBe(20);
+    expect(repaint).toHaveBeenCalled();
+  });
+
+  it('updates selection on pointer move', () => {
+    const store = makeStore(10);
+    const handler = new RangeSelectionHandler(
+      makeTimeScale() as never,
+      makePriceScale() as never,
+      () => store,
+      vi.fn(),
+    );
+    handler.active = true;
+    handler.onPointerDown(10, 50, 0);
+    handler.onPointerMove(80, 50, 0);
+    expect(handler.endX).toBe(80);
+  });
+
+  it('fires callback with stats on pointer up', () => {
+    const store = makeStore(10);
+    const ts = makeTimeScale();
+    const handler = new RangeSelectionHandler(
+      ts as never,
+      makePriceScale() as never,
+      () => store,
+      vi.fn(),
+    );
+    const cb = vi.fn();
+    handler.onRangeSelected(cb);
+    handler.active = true;
+
+    handler.onPointerDown(10, 50, 0);
+    handler.onPointerMove(80, 50, 0);
+    handler.onPointerUp(0);
+
+    expect(cb).toHaveBeenCalledTimes(1);
+    const stats = cb.mock.calls[0][0];
+    expect(stats).not.toBeNull();
+    expect(stats.barCount).toBeGreaterThan(0);
+    expect(typeof stats.high).toBe('number');
+    expect(typeof stats.low).toBe('number');
+    expect(typeof stats.totalVolume).toBe('number');
+  });
+
+  it('clears on Escape', () => {
+    const store = makeStore(10);
+    const repaint = vi.fn();
+    const handler = new RangeSelectionHandler(
+      makeTimeScale() as never,
+      makePriceScale() as never,
+      () => store,
+      repaint,
+    );
+    handler.active = true;
+    handler.onPointerDown(10, 50, 0);
+    expect(handler.selecting).toBe(true);
+    handler.onKeyDown('Escape', false);
+    expect(handler.selecting).toBe(false);
+  });
+
+  it('clears selection when deactivated', () => {
+    const store = makeStore(10);
+    const handler = new RangeSelectionHandler(
+      makeTimeScale() as never,
+      makePriceScale() as never,
+      () => store,
+      vi.fn(),
+    );
+    handler.active = true;
+    handler.onPointerDown(10, 50, 0);
+    handler.active = false;
+    expect(handler.selecting).toBe(false);
+  });
+
+  it('offRangeSelected removes callback', () => {
+    const store = makeStore(10);
+    const handler = new RangeSelectionHandler(
+      makeTimeScale() as never,
+      makePriceScale() as never,
+      () => store,
+      vi.fn(),
+    );
+    const cb = vi.fn();
+    handler.onRangeSelected(cb);
+    handler.offRangeSelected(cb);
+    handler.active = true;
+    handler.onPointerDown(10, 50, 0);
+    handler.onPointerMove(80, 50, 0);
+    handler.onPointerUp(0);
+    // The cb that we expect NOT to fire is the range selected one
+    // However, clear() fires cb(null). So the only call would be from clear in the constructor.
+    // Let's check that the stats callback was not called with a non-null value
+    const nonNullCalls = cb.mock.calls.filter((c: unknown[]) => c[0] !== null);
+    expect(nonNullCalls.length).toBe(0);
+  });
+});
+
+// ─── MeasureHandler ──────────────────────────────────────────────────────
+
+describe('MeasureHandler', () => {
+  it('starts inactive', () => {
+    const store = makeStore(10);
+    const handler = new MeasureHandler(
+      makeTimeScale() as never,
+      makePriceScale() as never,
+      () => store,
+      vi.fn(),
+    );
+    expect(handler.active).toBe(false);
+    expect(handler.firstPoint).toBeNull();
+  });
+
+  it('sets first point on first click', () => {
+    const store = makeStore(10);
+    const handler = new MeasureHandler(
+      makeTimeScale() as never,
+      makePriceScale() as never,
+      () => store,
+      vi.fn(),
+    );
+    handler.active = true;
+    handler.onPointerDown(30, 100, 0);
+    expect(handler.firstPoint).toEqual({ x: 30, y: 100 });
+    expect(handler.secondPoint).toBeNull();
+  });
+
+  it('computes result on second click', () => {
+    const store = makeStore(10);
+    const handler = new MeasureHandler(
+      makeTimeScale() as never,
+      makePriceScale() as never,
+      () => store,
+      vi.fn(),
+    );
+    const cb = vi.fn();
+    handler.onMeasure(cb);
+    handler.active = true;
+
+    handler.onPointerDown(10, 300, 0); // first point
+    handler.onPointerDown(80, 200, 0); // second point
+
+    expect(cb).toHaveBeenCalledTimes(1);
+    const result = cb.mock.calls[0][0];
+    expect(result).not.toBeNull();
+    expect(typeof result.priceChange).toBe('number');
+    expect(typeof result.percentChange).toBe('number');
+    expect(typeof result.barCount).toBe('number');
+    expect(typeof result.timeElapsed).toBe('number');
+  });
+
+  it('tracks hover after first click', () => {
+    const store = makeStore(10);
+    const handler = new MeasureHandler(
+      makeTimeScale() as never,
+      makePriceScale() as never,
+      () => store,
+      vi.fn(),
+    );
+    handler.active = true;
+    handler.onPointerDown(10, 300, 0);
+    handler.onPointerMove(50, 250, 0);
+    expect(handler.hovering).toBe(true);
+    expect(handler.hoverX).toBe(50);
+    expect(handler.hoverY).toBe(250);
+  });
+
+  it('clears on Escape', () => {
+    const store = makeStore(10);
+    const handler = new MeasureHandler(
+      makeTimeScale() as never,
+      makePriceScale() as never,
+      () => store,
+      vi.fn(),
+    );
+    handler.active = true;
+    handler.onPointerDown(10, 300, 0);
+    handler.onKeyDown('Escape', false);
+    expect(handler.firstPoint).toBeNull();
+  });
+
+  it('clears on deactivation', () => {
+    const store = makeStore(10);
+    const handler = new MeasureHandler(
+      makeTimeScale() as never,
+      makePriceScale() as never,
+      () => store,
+      vi.fn(),
+    );
+    handler.active = true;
+    handler.onPointerDown(10, 300, 0);
+    handler.active = false;
+    expect(handler.firstPoint).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary

- Add `chart.setRangeSelectionActive(true)` — drag to highlight a time range with summary stats (high, low, change, volume)
- Add `chart.setMeasureActive(true)` — click two points for price/time/% change display
- Both tools mutually exclusive, with Escape key cancellation
- Visual overlays: semi-transparent range highlight and dashed connector line with endpoints

Closes #28

## Test plan

- [x] 14 new unit tests covering activation, pointer events, stats computation, callback management
- [x] All 1244 tests pass
- [x] TypeScript compiles clean
- [x] Build succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)