### PR TITLE
feat: add segment tree for O(log n) min/max queries

### DIFF
--- a/src/api/chart-api.ts
+++ b/src/api/chart-api.ts
@@ -2963,14 +2963,15 @@ class ChartApi implements IChartApi {
 
     for (const entry of seriesForPane) {
       if (!entry.api.isVisible()) continue;
-      const rawStore = entry.api.getDataLayer().store;
+      const dataLayer = entry.api.getDataLayer();
+      const rawStore = dataLayer.store;
       const store = this._getEffectiveStore(entry, rawStore);
       const to = Math.min(range.toIdx, store.length - 1);
 
       const isLeft = entry.api.options().priceScaleId === 'left';
 
       if (this._comparisonMode) {
-        // In comparison mode auto-scale in percent space
+        // In comparison mode we must scan in percent space (no segment tree shortcut)
         const basis = this._getBasisPrice(entry, range);
         for (let i = range.fromIdx; i <= to; i++) {
           const loPct = basis === 0 ? 0 : ((store.low[i] - basis) / basis) * 100;
@@ -2984,15 +2985,29 @@ class ChartApi implements IChartApi {
           }
         }
       } else {
-        for (let i = range.fromIdx; i <= to; i++) {
-          const lo = store.low[i];
-          const hi = store.high[i];
+        // Use segment tree for O(log n) min/max when the store is the raw (non-transformed) one.
+        // Heikin-Ashi and other transforms produce a different store, so fall back to linear scan.
+        if (store === rawStore && dataLayer.segmentTree.length === store.length) {
+          const { min, max } = dataLayer.queryMinMax(range.fromIdx, to);
           if (isLeft) {
-            if (lo < leftMin) leftMin = lo;
-            if (hi > leftMax) leftMax = hi;
+            if (min < leftMin) leftMin = min;
+            if (max > leftMax) leftMax = max;
           } else {
-            if (lo < rightMin) rightMin = lo;
-            if (hi > rightMax) rightMax = hi;
+            if (min < rightMin) rightMin = min;
+            if (max > rightMax) rightMax = max;
+          }
+        } else {
+          // Linear scan fallback for transformed stores
+          for (let i = range.fromIdx; i <= to; i++) {
+            const lo = store.low[i];
+            const hi = store.high[i];
+            if (isLeft) {
+              if (lo < leftMin) leftMin = lo;
+              if (hi > leftMax) leftMax = hi;
+            } else {
+              if (lo < rightMin) rightMin = lo;
+              if (hi > rightMax) rightMax = hi;
+            }
           }
         }
       }

--- a/src/core/data-layer.ts
+++ b/src/core/data-layer.ts
@@ -5,12 +5,15 @@ import {
   barsToColumnStore,
   createColumnStore,
 } from './types';
+import { MinMaxSegmentTree } from './segment-tree';
 
 export class DataLayer {
   public store: ColumnStore;
+  public readonly segmentTree: MinMaxSegmentTree;
 
   constructor() {
     this.store = createColumnStore(2048);
+    this.segmentTree = new MinMaxSegmentTree(2048);
   }
 
   /** Load data. Accepts either an array of Bar objects or a ColumnData (typed arrays). */
@@ -31,6 +34,7 @@ export class DataLayer {
       store.volume.set(data.volume);
       this.store = store;
     }
+    this.segmentTree.build(this.store.high, this.store.low, this.store.length);
   }
 
   /**
@@ -48,6 +52,7 @@ export class DataLayer {
       store.low[i] = bar.low;
       store.close[i] = bar.close;
       store.volume[i] = bar.volume ?? 0;
+      this.segmentTree.update(i, bar.high, bar.low);
     } else {
       // Guard: out-of-order bars would corrupt the binary search in findIndex()
       if (store.length > 0 && bar.time < store.time[store.length - 1]) {
@@ -67,6 +72,7 @@ export class DataLayer {
       this.store.close[i] = bar.close;
       this.store.volume[i] = bar.volume ?? 0;
       this.store.length += 1;
+      this.segmentTree.append(bar.high, bar.low);
     }
   }
 
@@ -172,6 +178,15 @@ export class DataLayer {
     }
 
     this.store = newStore;
+    this.segmentTree.build(this.store.high, this.store.low, this.store.length);
+  }
+
+  /**
+   * Query the min low and max high in the range [fromIdx, toIdx] (inclusive).
+   * O(log n) time via segment tree.
+   */
+  queryMinMax(fromIdx: number, toIdx: number): { min: number; max: number } {
+    return this.segmentTree.query(fromIdx, toIdx);
   }
 
   /** Double the capacity of the store, preserving existing data. */

--- a/src/core/segment-tree.ts
+++ b/src/core/segment-tree.ts
@@ -1,0 +1,155 @@
+/**
+ * SegmentTree for O(log n) range min/max queries on Float64Array data.
+ *
+ * Supports incremental updates: when new data is appended, only the
+ * affected tree nodes are rebuilt — no full reconstruction needed.
+ */
+export class MinMaxSegmentTree {
+  private _minTree: Float64Array;
+  private _maxTree: Float64Array;
+  private _size: number; // number of leaves (rounded up to power of 2)
+  private _n: number; // actual data length
+
+  constructor(capacity: number) {
+    this._size = nextPow2(Math.max(capacity, 1));
+    this._minTree = new Float64Array(this._size * 2).fill(Infinity);
+    this._maxTree = new Float64Array(this._size * 2).fill(-Infinity);
+    this._n = 0;
+  }
+
+  get length(): number {
+    return this._n;
+  }
+
+  /**
+   * Build the tree from the given high/low arrays.
+   * O(n) time.
+   */
+  build(high: Float64Array, low: Float64Array, length: number): void {
+    this._n = length;
+
+    // Ensure capacity
+    if (length > this._size) {
+      this._size = nextPow2(length);
+      this._minTree = new Float64Array(this._size * 2).fill(Infinity);
+      this._maxTree = new Float64Array(this._size * 2).fill(-Infinity);
+    }
+
+    // Fill leaves
+    const offset = this._size;
+    for (let i = 0; i < length; i++) {
+      this._minTree[offset + i] = low[i];
+      this._maxTree[offset + i] = high[i];
+    }
+    // Clear remaining leaves
+    for (let i = length; i < this._size; i++) {
+      this._minTree[offset + i] = Infinity;
+      this._maxTree[offset + i] = -Infinity;
+    }
+
+    // Build internal nodes bottom-up
+    for (let i = offset - 1; i >= 1; i--) {
+      this._minTree[i] = Math.min(this._minTree[2 * i], this._minTree[2 * i + 1]);
+      this._maxTree[i] = Math.max(this._maxTree[2 * i], this._maxTree[2 * i + 1]);
+    }
+  }
+
+  /**
+   * Update a single index (e.g., when the last bar is modified).
+   * O(log n) time.
+   */
+  update(index: number, high: number, low: number): void {
+    let pos = this._size + index;
+    this._minTree[pos] = low;
+    this._maxTree[pos] = high;
+    pos >>= 1;
+    while (pos >= 1) {
+      this._minTree[pos] = Math.min(this._minTree[2 * pos], this._minTree[2 * pos + 1]);
+      this._maxTree[pos] = Math.max(this._maxTree[2 * pos], this._maxTree[2 * pos + 1]);
+      pos >>= 1;
+    }
+  }
+
+  /**
+   * Append a new value (for streaming data).
+   * O(log n) time.
+   */
+  append(high: number, low: number): void {
+    if (this._n >= this._size) {
+      this._grow();
+    }
+    this._minTree[this._size + this._n] = low;
+    this._maxTree[this._size + this._n] = high;
+    this._n++;
+
+    // Update ancestors
+    let pos = (this._size + this._n - 1) >> 1;
+    while (pos >= 1) {
+      this._minTree[pos] = Math.min(this._minTree[2 * pos], this._minTree[2 * pos + 1]);
+      this._maxTree[pos] = Math.max(this._maxTree[2 * pos], this._maxTree[2 * pos + 1]);
+      pos >>= 1;
+    }
+  }
+
+  /**
+   * Query the min low and max high in the range [from, to] (inclusive).
+   * O(log n) time.
+   */
+  query(from: number, to: number): { min: number; max: number } {
+    if (from > to || from >= this._n || to < 0) {
+      return { min: Infinity, max: -Infinity };
+    }
+    from = Math.max(0, from);
+    to = Math.min(this._n - 1, to);
+
+    let lo = from + this._size;
+    let hi = to + this._size;
+    let minVal = Infinity;
+    let maxVal = -Infinity;
+
+    while (lo <= hi) {
+      if (lo & 1) {
+        minVal = Math.min(minVal, this._minTree[lo]);
+        maxVal = Math.max(maxVal, this._maxTree[lo]);
+        lo++;
+      }
+      if (!(hi & 1)) {
+        minVal = Math.min(minVal, this._minTree[hi]);
+        maxVal = Math.max(maxVal, this._maxTree[hi]);
+        hi--;
+      }
+      lo >>= 1;
+      hi >>= 1;
+    }
+
+    return { min: minVal, max: maxVal };
+  }
+
+  private _grow(): void {
+    const newSize = this._size * 2;
+    const newMin = new Float64Array(newSize * 2).fill(Infinity);
+    const newMax = new Float64Array(newSize * 2).fill(-Infinity);
+
+    // Copy leaves
+    for (let i = 0; i < this._n; i++) {
+      newMin[newSize + i] = this._minTree[this._size + i];
+      newMax[newSize + i] = this._maxTree[this._size + i];
+    }
+
+    this._size = newSize;
+    this._minTree = newMin;
+    this._maxTree = newMax;
+
+    // Rebuild internal nodes
+    for (let i = newSize - 1; i >= 1; i--) {
+      this._minTree[i] = Math.min(this._minTree[2 * i], this._minTree[2 * i + 1]);
+      this._maxTree[i] = Math.max(this._maxTree[2 * i], this._maxTree[2 * i + 1]);
+    }
+  }
+}
+
+function nextPow2(n: number): number {
+  let p = 1;
+  while (p < n) p <<= 1;
+  return p;
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -54,6 +54,9 @@ export type {
 export { PriceLine } from './core/price-line';
 export type { PriceLineOptions } from './core/price-line';
 
+// ─── Segment Tree (large dataset optimization) ──────────────────────
+export { MinMaxSegmentTree } from './core/segment-tree';
+
 // ─── Range Selection & Measure ───────────────────────────────────────
 export type {
   RangeSelectionStats,

--- a/tests/core/segment-tree.test.ts
+++ b/tests/core/segment-tree.test.ts
@@ -1,0 +1,172 @@
+import { describe, it, expect } from 'vitest';
+import { MinMaxSegmentTree } from '@/core/segment-tree';
+
+describe('MinMaxSegmentTree', () => {
+  describe('build', () => {
+    it('builds from high/low arrays', () => {
+      const tree = new MinMaxSegmentTree(8);
+      const high = new Float64Array([110, 120, 115, 130, 125]);
+      const low = new Float64Array([90, 100, 95, 110, 105]);
+      tree.build(high, low, 5);
+      expect(tree.length).toBe(5);
+    });
+
+    it('handles empty data', () => {
+      const tree = new MinMaxSegmentTree(8);
+      tree.build(new Float64Array(0), new Float64Array(0), 0);
+      expect(tree.length).toBe(0);
+    });
+  });
+
+  describe('query', () => {
+    it('returns correct min/max for full range', () => {
+      const tree = new MinMaxSegmentTree(8);
+      const high = new Float64Array([110, 120, 115, 130, 125]);
+      const low = new Float64Array([90, 100, 95, 110, 105]);
+      tree.build(high, low, 5);
+
+      const result = tree.query(0, 4);
+      expect(result.min).toBe(90);
+      expect(result.max).toBe(130);
+    });
+
+    it('returns correct min/max for partial range', () => {
+      const tree = new MinMaxSegmentTree(8);
+      const high = new Float64Array([110, 120, 115, 130, 125]);
+      const low = new Float64Array([90, 100, 95, 110, 105]);
+      tree.build(high, low, 5);
+
+      const result = tree.query(1, 3);
+      expect(result.min).toBe(95); // min of low[1..3] = min(100, 95, 110)
+      expect(result.max).toBe(130); // max of high[1..3] = max(120, 115, 130)
+    });
+
+    it('returns correct min/max for single element', () => {
+      const tree = new MinMaxSegmentTree(8);
+      const high = new Float64Array([110, 120, 115]);
+      const low = new Float64Array([90, 100, 95]);
+      tree.build(high, low, 3);
+
+      const result = tree.query(1, 1);
+      expect(result.min).toBe(100);
+      expect(result.max).toBe(120);
+    });
+
+    it('handles out-of-bounds range', () => {
+      const tree = new MinMaxSegmentTree(8);
+      const high = new Float64Array([110, 120]);
+      const low = new Float64Array([90, 100]);
+      tree.build(high, low, 2);
+
+      const result = tree.query(5, 10);
+      expect(result.min).toBe(Infinity);
+      expect(result.max).toBe(-Infinity);
+    });
+
+    it('clamps to valid range', () => {
+      const tree = new MinMaxSegmentTree(8);
+      const high = new Float64Array([110, 120, 115]);
+      const low = new Float64Array([90, 100, 95]);
+      tree.build(high, low, 3);
+
+      const result = tree.query(-1, 10);
+      expect(result.min).toBe(90);
+      expect(result.max).toBe(120);
+    });
+  });
+
+  describe('update', () => {
+    it('updates a single element', () => {
+      const tree = new MinMaxSegmentTree(8);
+      const high = new Float64Array([110, 120, 115]);
+      const low = new Float64Array([90, 100, 95]);
+      tree.build(high, low, 3);
+
+      // Update index 1: new high=200, new low=50
+      tree.update(1, 200, 50);
+
+      const result = tree.query(0, 2);
+      expect(result.min).toBe(50);
+      expect(result.max).toBe(200);
+    });
+
+    it('update only affects the queried range', () => {
+      const tree = new MinMaxSegmentTree(8);
+      const high = new Float64Array([110, 120, 115, 130]);
+      const low = new Float64Array([90, 100, 95, 110]);
+      tree.build(high, low, 4);
+
+      tree.update(3, 200, 50); // Update last element
+
+      // Range [0, 2] should NOT be affected
+      const partial = tree.query(0, 2);
+      expect(partial.min).toBe(90);
+      expect(partial.max).toBe(120);
+
+      // Full range should reflect the update
+      const full = tree.query(0, 3);
+      expect(full.min).toBe(50);
+      expect(full.max).toBe(200);
+    });
+  });
+
+  describe('append', () => {
+    it('appends new values', () => {
+      const tree = new MinMaxSegmentTree(8);
+      const high = new Float64Array([110, 120]);
+      const low = new Float64Array([90, 100]);
+      tree.build(high, low, 2);
+
+      tree.append(200, 50);
+      expect(tree.length).toBe(3);
+
+      const result = tree.query(0, 2);
+      expect(result.min).toBe(50);
+      expect(result.max).toBe(200);
+    });
+
+    it('grows capacity when needed', () => {
+      const tree = new MinMaxSegmentTree(2);
+      tree.build(new Float64Array([100, 200]), new Float64Array([50, 80]), 2);
+
+      // Append beyond initial capacity
+      tree.append(300, 30);
+      tree.append(150, 70);
+
+      expect(tree.length).toBe(4);
+      const result = tree.query(0, 3);
+      expect(result.min).toBe(30);
+      expect(result.max).toBe(300);
+    });
+  });
+
+  describe('large dataset performance', () => {
+    it('handles 100k elements correctly', () => {
+      const n = 100_000;
+      const high = new Float64Array(n);
+      const low = new Float64Array(n);
+      for (let i = 0; i < n; i++) {
+        high[i] = 100 + Math.sin(i * 0.01) * 50;
+        low[i] = 100 + Math.sin(i * 0.01) * 50 - 10;
+      }
+
+      const tree = new MinMaxSegmentTree(n);
+      tree.build(high, low, n);
+
+      // Query a middle range
+      const result = tree.query(40000, 60000);
+      expect(result.min).toBeLessThan(result.max);
+      expect(result.min).toBeGreaterThan(0);
+
+      // Verify correctness against linear scan
+      let expectedMin = Infinity;
+      let expectedMax = -Infinity;
+      for (let i = 40000; i <= 60000; i++) {
+        if (low[i] < expectedMin) expectedMin = low[i];
+        if (high[i] > expectedMax) expectedMax = high[i];
+      }
+      expect(result.min).toBeCloseTo(expectedMin, 10);
+      expect(result.max).toBeCloseTo(expectedMax, 10);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- Add `MinMaxSegmentTree` for O(log n) range min/max queries on OHLC data
- Integrate into `DataLayer`: tree built on setData/prepend, incrementally updated on streaming
- `_updatePaneDataRange` uses segment tree for non-comparison mode, falls back to linear scan for Heikin-Ashi
- Correctness verified against linear scan for 100k element datasets

Closes #32

## Test plan

- [x] 12 new unit tests: build, query (full/partial/single/out-of-bounds), update, append, grow, 100k correctness
- [x] All 1256 tests pass
- [x] TypeScript compiles clean
- [x] Build succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)