### PR TITLE
feat: add logarithmic price scale

### DIFF
--- a/src/api/chart-api.ts
+++ b/src/api/chart-api.ts
@@ -522,6 +522,8 @@ class ChartApi implements IChartApi {
     // Create main pane
     const mainPaneHeight = this._height - TIME_AXIS_HEIGHT;
     const mainPane = new Pane(this._mainPaneId, mainPaneHeight, this._useWebGL);
+    if (options.rightPriceScale?.mode) mainPane.priceScale.setMode(options.rightPriceScale.mode);
+    if (options.leftPriceScale?.mode) mainPane.leftPriceScale.setMode(options.leftPriceScale.mode);
     this._paneMap.set(this._mainPaneId, mainPane);
     this._paneOrder.push(this._mainPaneId);
     this._paneContainer.appendChild(mainPane.row);
@@ -969,6 +971,18 @@ class ChartApi implements IChartApi {
 
     if (options.timeScale) {
       this._timeScale.setOptions(this._options.timeScale);
+    }
+
+    // Sync price scale modes
+    if (options.rightPriceScale?.mode) {
+      for (const pane of this._paneMap.values()) {
+        pane.priceScale.setMode(this._options.rightPriceScale.mode ?? 'linear');
+      }
+    }
+    if (options.leftPriceScale?.mode) {
+      for (const pane of this._paneMap.values()) {
+        pane.leftPriceScale.setMode(this._options.leftPriceScale.mode ?? 'linear');
+      }
     }
 
     // Re-layout canvases if scale visibility changed

--- a/src/api/options.ts
+++ b/src/api/options.ts
@@ -86,6 +86,8 @@ export interface VolumeOverlayOptions {
 
 export interface PriceScaleOptions {
   visible: boolean;
+  /** Scale mode: 'linear' (default) or 'logarithmic'. */
+  mode?: import('../core/price-scale').PriceScaleMode;
 }
 
 export interface TimeGapsOptions {

--- a/src/core/price-scale.ts
+++ b/src/core/price-scale.ts
@@ -1,3 +1,5 @@
+export type PriceScaleMode = 'linear' | 'logarithmic';
+
 export interface PriceRange {
   min: number;
   max: number;
@@ -41,9 +43,20 @@ export class PriceScale {
   /** When true, setRange() was called manually and autoScale() will not override it. */
   private _manualRange: boolean = false;
   private _comparisonMode: boolean = false;
+  private _mode: PriceScaleMode = 'linear';
 
   constructor(position: 'left' | 'right') {
     this.position = position;
+  }
+
+  /** Get the current scale mode. */
+  get mode(): PriceScaleMode {
+    return this._mode;
+  }
+
+  /** Set the scale mode (linear or logarithmic). */
+  setMode(mode: PriceScaleMode): void {
+    this._mode = mode;
   }
 
   setHeight(height: number): void {
@@ -160,12 +173,10 @@ export class PriceScale {
   }
 
   /**
-   * Map a price to a y-pixel coordinate using TV's formula:
-   *   topPx = height * TOP_MARGIN
-   *   bottomPx = height * BOTTOM_MARGIN
-   *   innerHeight = height - topPx - bottomPx
-   *   invCoord = bottomPx + (innerHeight - 1) * (price - min) / (max - min)
-   *   y = height - 1 - invCoord
+   * Map a price to a y-pixel coordinate.
+   *
+   * In linear mode: equal vertical distance for equal price change.
+   * In logarithmic mode: equal vertical distance for equal percentage change.
    */
   priceToY(price: number): number {
     if (this._height === 0 || this._max === this._min) return 0;
@@ -174,7 +185,16 @@ export class PriceScale {
     const bottomPx = this._height * BOTTOM_MARGIN;
     const innerHeight = this._height - topPx - bottomPx;
 
-    const invCoord = bottomPx + (innerHeight - 1) * (price - this._min) / (this._max - this._min);
+    let ratio: number;
+    if (this._mode === 'logarithmic' && this._min > 0 && price > 0) {
+      const logMin = Math.log(this._min);
+      const logMax = Math.log(this._max);
+      ratio = (Math.log(price) - logMin) / (logMax - logMin);
+    } else {
+      ratio = (price - this._min) / (this._max - this._min);
+    }
+
+    const invCoord = bottomPx + (innerHeight - 1) * ratio;
     return this._height - 1 - invCoord;
   }
 
@@ -186,10 +206,15 @@ export class PriceScale {
     const bottomPx = this._height * BOTTOM_MARGIN;
     const innerHeight = this._height - topPx - bottomPx;
 
-    // y = height - 1 - invCoord  =>  invCoord = height - 1 - y
     const invCoord = this._height - 1 - y;
-    // invCoord = bottomPx + (innerHeight - 1) * (price - min) / (max - min)
     const ratio = (invCoord - bottomPx) / (innerHeight - 1);
+
+    if (this._mode === 'logarithmic' && this._min > 0) {
+      const logMin = Math.log(this._min);
+      const logMax = Math.log(this._max);
+      return Math.exp(logMin + ratio * (logMax - logMin));
+    }
+
     return this._min + ratio * (this._max - this._min);
   }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -54,6 +54,9 @@ export type {
 export { PriceLine } from './core/price-line';
 export type { PriceLineOptions } from './core/price-line';
 
+// ─── Price Scale ────────────────────────────────────────────────────
+export type { PriceScaleMode } from './core/price-scale';
+
 // ─── Undo/Redo ──────────────────────────────────────────────────────
 export { UndoRedoManager } from './core/undo-redo';
 export type { Command, UndoRedoChangeCallback } from './core/undo-redo';

--- a/tests/core/price-scale.test.ts
+++ b/tests/core/price-scale.test.ts
@@ -120,4 +120,69 @@ describe('PriceScale', () => {
     expect(ps.position).toBe('right');
     expect(new PriceScale('left').position).toBe('left');
   });
+
+  // ── Logarithmic mode ──────────────────────────────────────────────────
+
+  describe('logarithmic mode', () => {
+    beforeEach(() => {
+      ps.setMode('logarithmic');
+    });
+
+    it('defaults to linear mode', () => {
+      const fresh = new PriceScale('right');
+      expect(fresh.mode).toBe('linear');
+    });
+
+    it('setMode changes the mode', () => {
+      expect(ps.mode).toBe('logarithmic');
+      ps.setMode('linear');
+      expect(ps.mode).toBe('linear');
+    });
+
+    it('priceToY maps equal percentage changes to equal pixel distances', () => {
+      ps.setRange(100, 10000);
+      // In log mode: 100 → 1000 is the same % change as 1000 → 10000 (10x each)
+      const y100 = ps.priceToY(100);
+      const y1000 = ps.priceToY(1000);
+      const y10000 = ps.priceToY(10000);
+      const dist1 = y100 - y1000;   // top to mid
+      const dist2 = y1000 - y10000; // mid to bottom
+      expect(dist1).toBeCloseTo(dist2, 0);
+    });
+
+    it('priceToY is NOT linear in log mode', () => {
+      ps.setRange(100, 10000);
+      const yMid = ps.priceToY(5050); // arithmetic midpoint
+      const yTop = ps.priceToY(10000);
+      const yBot = ps.priceToY(100);
+      const linearMid = (yTop + yBot) / 2;
+      // In log mode, the arithmetic midpoint should NOT be at the pixel midpoint
+      expect(Math.abs(yMid - linearMid)).toBeGreaterThan(5);
+    });
+
+    it('yToPrice is the inverse of priceToY in log mode', () => {
+      ps.setRange(10, 10000);
+      for (const price of [10, 100, 1000, 5000, 10000]) {
+        expect(ps.yToPrice(ps.priceToY(price))).toBeCloseTo(price, 0);
+      }
+    });
+
+    it('falls back to linear when min <= 0', () => {
+      ps.setRange(0, 100);
+      // Should not crash and should behave like linear
+      const yMid = ps.priceToY(50);
+      const yTop = ps.priceToY(100);
+      const yBot = ps.priceToY(0);
+      // Linear: midpoint at pixel center
+      const linearMid = (yTop + yBot) / 2;
+      expect(yMid).toBeCloseTo(linearMid, 0);
+    });
+
+    it('falls back to linear when price <= 0', () => {
+      ps.setRange(1, 100);
+      // Negative price in log mode: fall back to linear mapping
+      const y = ps.priceToY(-10);
+      expect(isFinite(y)).toBe(true);
+    });
+  });
 });


### PR DESCRIPTION
## Summary

- Add `PriceScaleMode` type (`'linear' | 'logarithmic'`) to `PriceScale`
- Configure via `chart.applyOptions({ rightPriceScale: { mode: 'logarithmic' } })`
- Log mode: equal vertical distances = equal percentage changes (natural log mapping)
- Graceful fallback to linear when price or min <= 0
- Drawing tools and indicators work correctly on log scale via existing priceToY/yToPrice

Closes #39

## Test plan

- [x] 7 new tests: equal % → equal pixels, non-linearity, roundtrip, fallback for min<=0 and price<=0
- [x] All 1278 tests pass
- [x] TypeScript compiles clean, build succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)