### PR TITLE
feat: add data feed abstraction with pagination and caching

### DIFF
--- a/src/core/data-feed.ts
+++ b/src/core/data-feed.ts
@@ -1,0 +1,166 @@
+import type { Bar } from './types';
+
+/**
+ * IDataFeed — abstraction for fetching OHLCV bar data with pagination.
+ *
+ * Implementations provide a `getBars()` method that the chart calls when
+ * the user scrolls to the edge and more historical data is needed.
+ */
+export interface IDataFeed {
+  /**
+   * Fetch bars for the given symbol and resolution within the time range.
+   * @param symbol - Symbol identifier (e.g., 'AAPL', 'BTCUSD')
+   * @param resolution - Bar interval (e.g., '1', '5', '15', '60', 'D', 'W')
+   * @param from - Start of range (Unix timestamp, seconds)
+   * @param to - End of range (Unix timestamp, seconds)
+   * @returns Promise resolving to an array of bars, sorted by time ascending.
+   *          Empty array means no more data available for the requested range.
+   */
+  getBars(symbol: string, resolution: string, from: number, to: number): Promise<Bar[]>;
+}
+
+/**
+ * CacheEntry tracks fetched ranges to avoid duplicate requests.
+ */
+interface CacheEntry {
+  from: number;
+  to: number;
+  bars: Bar[];
+}
+
+export interface DataFeedManagerOptions {
+  /** Maximum number of cached range entries per symbol+resolution (default: 100). */
+  maxCacheEntries?: number;
+}
+
+/**
+ * DataFeedManager wraps an IDataFeed with:
+ * - Request deduplication (won't re-fetch the same range)
+ * - Local cache with configurable size limit
+ * - Gap detection for missing ranges
+ * - Loading state tracking
+ */
+export class DataFeedManager {
+  private _feed: IDataFeed;
+  private _cache: Map<string, CacheEntry[]> = new Map();
+  private _pendingRequests: Map<string, Promise<Bar[]>> = new Map();
+  private _loading = false;
+  private _maxCacheEntries: number;
+
+  constructor(feed: IDataFeed, options: DataFeedManagerOptions = {}) {
+    this._feed = feed;
+    this._maxCacheEntries = options.maxCacheEntries ?? 100;
+  }
+
+  /** Whether a fetch is currently in progress. */
+  get loading(): boolean {
+    return this._loading;
+  }
+
+  /**
+   * Fetch bars with deduplication and caching.
+   * If the requested range (or a superset) is already cached, returns cached data.
+   * Otherwise fetches from the underlying data feed and caches the result.
+   */
+  async getBars(
+    symbol: string,
+    resolution: string,
+    from: number,
+    to: number,
+  ): Promise<Bar[]> {
+    const key = `${symbol}:${resolution}`;
+
+    // Check cache first
+    const cached = this._findCachedBars(key, from, to);
+    if (cached !== null) return cached;
+
+    // Deduplicate: if an identical request is in-flight, reuse it
+    const requestKey = `${key}:${from}:${to}`;
+    const pending = this._pendingRequests.get(requestKey);
+    if (pending) return pending;
+
+    // Fetch from feed
+    this._loading = true;
+    const promise = this._feed.getBars(symbol, resolution, from, to)
+      .then((bars) => {
+        this._addToCache(key, from, to, bars);
+        return bars;
+      })
+      .finally(() => {
+        this._pendingRequests.delete(requestKey);
+        this._loading = this._pendingRequests.size > 0;
+      });
+
+    this._pendingRequests.set(requestKey, promise);
+    return promise;
+  }
+
+  /**
+   * Detect gaps in cached data and return the missing ranges that need fetching.
+   */
+  findGaps(symbol: string, resolution: string, from: number, to: number): Array<{ from: number; to: number }> {
+    const key = `${symbol}:${resolution}`;
+    const entries = this._cache.get(key) ?? [];
+    if (entries.length === 0) return [{ from, to }];
+
+    // Sort entries by from time
+    const sorted = [...entries].sort((a, b) => a.from - b.from);
+    const gaps: Array<{ from: number; to: number }> = [];
+
+    let cursor = from;
+    for (const entry of sorted) {
+      if (entry.from > cursor) {
+        gaps.push({ from: cursor, to: Math.min(entry.from, to) });
+      }
+      cursor = Math.max(cursor, entry.to);
+      if (cursor >= to) break;
+    }
+    if (cursor < to) {
+      gaps.push({ from: cursor, to });
+    }
+
+    return gaps;
+  }
+
+  /** Clear the cache for a specific symbol+resolution, or all if not specified. */
+  clearCache(symbol?: string, resolution?: string): void {
+    if (symbol && resolution) {
+      this._cache.delete(`${symbol}:${resolution}`);
+    } else {
+      this._cache.clear();
+    }
+  }
+
+  /** Get the number of cached entries for a symbol+resolution. */
+  cacheSize(symbol: string, resolution: string): number {
+    return this._cache.get(`${symbol}:${resolution}`)?.length ?? 0;
+  }
+
+  private _findCachedBars(key: string, from: number, to: number): Bar[] | null {
+    const entries = this._cache.get(key);
+    if (!entries) return null;
+
+    // Look for a single entry that covers the full range
+    for (const entry of entries) {
+      if (entry.from <= from && entry.to >= to) {
+        return entry.bars.filter((b) => b.time >= from && b.time <= to);
+      }
+    }
+    return null;
+  }
+
+  private _addToCache(key: string, from: number, to: number, bars: Bar[]): void {
+    let entries = this._cache.get(key);
+    if (!entries) {
+      entries = [];
+      this._cache.set(key, entries);
+    }
+
+    entries.push({ from, to, bars: [...bars] });
+
+    // Enforce max cache size
+    if (entries.length > this._maxCacheEntries) {
+      entries.shift(); // Remove oldest
+    }
+  }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -54,6 +54,10 @@ export type {
 export { PriceLine } from './core/price-line';
 export type { PriceLineOptions } from './core/price-line';
 
+// ─── Data Feed ──────────────────────────────────────────────────────
+export { DataFeedManager } from './core/data-feed';
+export type { IDataFeed, DataFeedManagerOptions } from './core/data-feed';
+
 // ─── Price Scale ────────────────────────────────────────────────────
 export type { PriceScaleMode } from './core/price-scale';
 

--- a/tests/core/data-feed.test.ts
+++ b/tests/core/data-feed.test.ts
@@ -1,0 +1,180 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { DataFeedManager } from '@/core/data-feed';
+import type { IDataFeed } from '@/core/data-feed';
+import type { Bar } from '@/core/types';
+
+function makeBars(from: number, to: number, step = 86400): Bar[] {
+  const bars: Bar[] = [];
+  for (let t = from; t <= to; t += step) {
+    bars.push({ time: t, open: 100, high: 110, low: 90, close: 105, volume: 1000 });
+  }
+  return bars;
+}
+
+function makeMockFeed(bars: Bar[] = []): IDataFeed {
+  return {
+    getBars: vi.fn().mockResolvedValue(bars),
+  };
+}
+
+describe('DataFeedManager', () => {
+  describe('getBars', () => {
+    it('fetches from the underlying feed', async () => {
+      const bars = makeBars(1000, 5000);
+      const feed = makeMockFeed(bars);
+      const mgr = new DataFeedManager(feed);
+
+      const result = await mgr.getBars('AAPL', 'D', 1000, 5000);
+      expect(result).toEqual(bars);
+      expect(feed.getBars).toHaveBeenCalledWith('AAPL', 'D', 1000, 5000);
+    });
+
+    it('returns cached data on second request for same range', async () => {
+      const bars = makeBars(1000, 5000);
+      const feed = makeMockFeed(bars);
+      const mgr = new DataFeedManager(feed);
+
+      await mgr.getBars('AAPL', 'D', 1000, 5000);
+      const result = await mgr.getBars('AAPL', 'D', 1000, 5000);
+
+      expect(result).toEqual(bars);
+      expect(feed.getBars).toHaveBeenCalledTimes(1); // Not called again
+    });
+
+    it('returns subset from cache for sub-range request', async () => {
+      const bars = makeBars(1000, 10000);
+      const feed = makeMockFeed(bars);
+      const mgr = new DataFeedManager(feed);
+
+      await mgr.getBars('AAPL', 'D', 1000, 10000);
+      const result = await mgr.getBars('AAPL', 'D', 3000, 7000);
+
+      expect(feed.getBars).toHaveBeenCalledTimes(1);
+      expect(result.every((b) => b.time >= 3000 && b.time <= 7000)).toBe(true);
+    });
+
+    it('deduplicates in-flight requests', async () => {
+      const bars = makeBars(1000, 5000);
+      const feed: IDataFeed = {
+        getBars: vi.fn().mockImplementation(() =>
+          new Promise((resolve) => setTimeout(() => resolve(bars), 10)),
+        ),
+      };
+      const mgr = new DataFeedManager(feed);
+
+      // Fire two identical requests simultaneously
+      const [r1, r2] = await Promise.all([
+        mgr.getBars('AAPL', 'D', 1000, 5000),
+        mgr.getBars('AAPL', 'D', 1000, 5000),
+      ]);
+
+      expect(feed.getBars).toHaveBeenCalledTimes(1);
+      expect(r1).toEqual(r2);
+    });
+
+    it('separates cache by symbol and resolution', async () => {
+      const aaplBars = makeBars(1000, 5000);
+      const googBars = makeBars(1000, 5000);
+      const feed: IDataFeed = {
+        getBars: vi.fn()
+          .mockResolvedValueOnce(aaplBars)
+          .mockResolvedValueOnce(googBars),
+      };
+      const mgr = new DataFeedManager(feed);
+
+      await mgr.getBars('AAPL', 'D', 1000, 5000);
+      await mgr.getBars('GOOG', 'D', 1000, 5000);
+
+      expect(feed.getBars).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  describe('loading', () => {
+    it('tracks loading state', async () => {
+      let resolvePromise!: (bars: Bar[]) => void;
+      const feed: IDataFeed = {
+        getBars: vi.fn().mockImplementation(() =>
+          new Promise((resolve) => { resolvePromise = resolve; }),
+        ),
+      };
+      const mgr = new DataFeedManager(feed);
+
+      expect(mgr.loading).toBe(false);
+      const promise = mgr.getBars('AAPL', 'D', 1000, 5000);
+      expect(mgr.loading).toBe(true);
+      resolvePromise([]);
+      await promise;
+      expect(mgr.loading).toBe(false);
+    });
+  });
+
+  describe('findGaps', () => {
+    it('returns full range when cache is empty', () => {
+      const feed = makeMockFeed();
+      const mgr = new DataFeedManager(feed);
+      const gaps = mgr.findGaps('AAPL', 'D', 1000, 5000);
+      expect(gaps).toEqual([{ from: 1000, to: 5000 }]);
+    });
+
+    it('finds gaps between cached ranges', async () => {
+      const feed: IDataFeed = {
+        getBars: vi.fn().mockResolvedValue([]),
+      };
+      const mgr = new DataFeedManager(feed);
+
+      // Cache two ranges with a gap between them
+      await mgr.getBars('AAPL', 'D', 1000, 3000);
+      await mgr.getBars('AAPL', 'D', 5000, 7000);
+
+      const gaps = mgr.findGaps('AAPL', 'D', 1000, 7000);
+      expect(gaps).toEqual([{ from: 3000, to: 5000 }]);
+    });
+
+    it('returns no gaps when range is fully covered', async () => {
+      const feed = makeMockFeed([]);
+      const mgr = new DataFeedManager(feed);
+
+      await mgr.getBars('AAPL', 'D', 1000, 10000);
+      const gaps = mgr.findGaps('AAPL', 'D', 3000, 7000);
+      expect(gaps).toEqual([]);
+    });
+  });
+
+  describe('clearCache', () => {
+    it('clears cache for specific symbol+resolution', async () => {
+      const feed = makeMockFeed(makeBars(1000, 5000));
+      const mgr = new DataFeedManager(feed);
+
+      await mgr.getBars('AAPL', 'D', 1000, 5000);
+      expect(mgr.cacheSize('AAPL', 'D')).toBe(1);
+
+      mgr.clearCache('AAPL', 'D');
+      expect(mgr.cacheSize('AAPL', 'D')).toBe(0);
+    });
+
+    it('clears all cache when no args provided', async () => {
+      const feed = makeMockFeed(makeBars(1000, 5000));
+      const mgr = new DataFeedManager(feed);
+
+      await mgr.getBars('AAPL', 'D', 1000, 5000);
+      await mgr.getBars('GOOG', 'D', 1000, 5000);
+
+      mgr.clearCache();
+      expect(mgr.cacheSize('AAPL', 'D')).toBe(0);
+      expect(mgr.cacheSize('GOOG', 'D')).toBe(0);
+    });
+  });
+
+  describe('cache limit', () => {
+    it('enforces maxCacheEntries', async () => {
+      const feed = makeMockFeed([]);
+      const mgr = new DataFeedManager(feed, { maxCacheEntries: 3 });
+
+      for (let i = 0; i < 5; i++) {
+        await mgr.getBars('AAPL', 'D', i * 1000, (i + 1) * 1000);
+      }
+
+      expect(mgr.cacheSize('AAPL', 'D')).toBe(3);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- Define `IDataFeed` interface with `getBars(symbol, resolution, from, to)` method
- Add `DataFeedManager` with request deduplication, local cache, gap detection, and loading state
- Cache supports sub-range hits, configurable size limit, and per-symbol+resolution isolation

Closes #42

## Test plan

- [x] 12 new tests: fetching, caching, deduplication, sub-range, gaps, loading state, cache limit, clear
- [x] All 1290 tests pass
- [x] TypeScript compiles clean, build succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)