### PR TITLE
feat: add CSS custom properties for runtime theming

### DIFF
--- a/src/core/css-theme.ts
+++ b/src/core/css-theme.ts
@@ -1,0 +1,144 @@
+import type { DeepPartial } from './types';
+import type { ChartOptions } from '../api/options';
+
+/**
+ * CSS custom property names used by fin-charter.
+ * All prefixed with --fc- to avoid collisions.
+ */
+export const CSS_VARS = {
+  // Layout
+  bg: '--fc-bg',
+  text: '--fc-text',
+  fontSize: '--fc-font-size',
+  fontFamily: '--fc-font-family',
+
+  // Grid
+  gridHorzColor: '--fc-grid-horz-color',
+  gridVertColor: '--fc-grid-vert-color',
+
+  // Crosshair
+  crosshairVertColor: '--fc-crosshair-vert-color',
+  crosshairHorzColor: '--fc-crosshair-horz-color',
+
+  // Series
+  candleUpColor: '--fc-candle-up',
+  candleDownColor: '--fc-candle-down',
+  lineColor: '--fc-line-color',
+  areaTopColor: '--fc-area-top',
+  areaBottomColor: '--fc-area-bottom',
+  areaLineColor: '--fc-area-line',
+
+  // Volume
+  volumeUpColor: '--fc-volume-up',
+  volumeDownColor: '--fc-volume-down',
+
+  // Watermark
+  watermarkColor: '--fc-watermark-color',
+} as const;
+
+/**
+ * Read CSS custom properties from a container element and return
+ * a partial ChartOptions object. Undefined properties (not set in CSS)
+ * are omitted so mergeOptions will skip them.
+ */
+export function readCSSTheme(container: HTMLElement): DeepPartial<ChartOptions> {
+  const style = getComputedStyle(container);
+  const get = (name: string): string | undefined => {
+    const val = style.getPropertyValue(name).trim();
+    return val || undefined;
+  };
+
+  const bg = get(CSS_VARS.bg);
+  const text = get(CSS_VARS.text);
+  const fontSizeStr = get(CSS_VARS.fontSize);
+  const fontFamily = get(CSS_VARS.fontFamily);
+
+  const opts: DeepPartial<ChartOptions> = {};
+
+  if (bg || text || fontSizeStr || fontFamily) {
+    opts.layout = {};
+    if (bg) opts.layout.backgroundColor = bg;
+    if (text) opts.layout.textColor = text;
+    if (fontSizeStr) opts.layout.fontSize = parseInt(fontSizeStr, 10);
+    if (fontFamily) opts.layout.fontFamily = fontFamily;
+  }
+
+  const gridH = get(CSS_VARS.gridHorzColor);
+  const gridV = get(CSS_VARS.gridVertColor);
+  if (gridH || gridV) {
+    opts.grid = {};
+    if (gridH) opts.grid.horzLinesColor = gridH;
+    if (gridV) opts.grid.vertLinesColor = gridV;
+  }
+
+  const chV = get(CSS_VARS.crosshairVertColor);
+  const chH = get(CSS_VARS.crosshairHorzColor);
+  if (chV || chH) {
+    opts.crosshair = {};
+    if (chV) opts.crosshair.vertLineColor = chV;
+    if (chH) opts.crosshair.horzLineColor = chH;
+  }
+
+  const volUp = get(CSS_VARS.volumeUpColor);
+  const volDown = get(CSS_VARS.volumeDownColor);
+  if (volUp || volDown) {
+    opts.volume = {};
+    if (volUp) opts.volume.upColor = volUp;
+    if (volDown) opts.volume.downColor = volDown;
+  }
+
+  const wmColor = get(CSS_VARS.watermarkColor);
+  if (wmColor) {
+    opts.watermark = { color: wmColor };
+  }
+
+  return opts;
+}
+
+/**
+ * Generate a CSS string that sets all custom properties for a theme.
+ * Can be applied to a container element via `element.style.cssText` or
+ * inserted into a <style> block.
+ */
+export function generateCSSTheme(options: DeepPartial<ChartOptions>): string {
+  const vars: string[] = [];
+
+  if (options.layout?.backgroundColor) vars.push(`${CSS_VARS.bg}: ${options.layout.backgroundColor}`);
+  if (options.layout?.textColor) vars.push(`${CSS_VARS.text}: ${options.layout.textColor}`);
+  if (options.layout?.fontSize) vars.push(`${CSS_VARS.fontSize}: ${options.layout.fontSize}px`);
+  if (options.layout?.fontFamily) vars.push(`${CSS_VARS.fontFamily}: ${options.layout.fontFamily}`);
+
+  if (options.grid?.horzLinesColor) vars.push(`${CSS_VARS.gridHorzColor}: ${options.grid.horzLinesColor}`);
+  if (options.grid?.vertLinesColor) vars.push(`${CSS_VARS.gridVertColor}: ${options.grid.vertLinesColor}`);
+
+  if (options.crosshair?.vertLineColor) vars.push(`${CSS_VARS.crosshairVertColor}: ${options.crosshair.vertLineColor}`);
+  if (options.crosshair?.horzLineColor) vars.push(`${CSS_VARS.crosshairHorzColor}: ${options.crosshair.horzLineColor}`);
+
+  if (options.volume?.upColor) vars.push(`${CSS_VARS.volumeUpColor}: ${options.volume.upColor}`);
+  if (options.volume?.downColor) vars.push(`${CSS_VARS.volumeDownColor}: ${options.volume.downColor}`);
+
+  if (options.watermark?.color) vars.push(`${CSS_VARS.watermarkColor}: ${options.watermark.color}`);
+
+  return vars.join(';\n');
+}
+
+/**
+ * Apply CSS custom properties for a theme directly to an element.
+ */
+export function applyCSSTheme(element: HTMLElement, options: DeepPartial<ChartOptions>): void {
+  if (options.layout?.backgroundColor) element.style.setProperty(CSS_VARS.bg, options.layout.backgroundColor);
+  if (options.layout?.textColor) element.style.setProperty(CSS_VARS.text, options.layout.textColor);
+  if (options.layout?.fontSize) element.style.setProperty(CSS_VARS.fontSize, `${options.layout.fontSize}px`);
+  if (options.layout?.fontFamily) element.style.setProperty(CSS_VARS.fontFamily, options.layout.fontFamily);
+
+  if (options.grid?.horzLinesColor) element.style.setProperty(CSS_VARS.gridHorzColor, options.grid.horzLinesColor);
+  if (options.grid?.vertLinesColor) element.style.setProperty(CSS_VARS.gridVertColor, options.grid.vertLinesColor);
+
+  if (options.crosshair?.vertLineColor) element.style.setProperty(CSS_VARS.crosshairVertColor, options.crosshair.vertLineColor);
+  if (options.crosshair?.horzLineColor) element.style.setProperty(CSS_VARS.crosshairHorzColor, options.crosshair.horzLineColor);
+
+  if (options.volume?.upColor) element.style.setProperty(CSS_VARS.volumeUpColor, options.volume.upColor);
+  if (options.volume?.downColor) element.style.setProperty(CSS_VARS.volumeDownColor, options.volume.downColor);
+
+  if (options.watermark?.color) element.style.setProperty(CSS_VARS.watermarkColor, options.watermark.color);
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -54,6 +54,9 @@ export type {
 export { PriceLine } from './core/price-line';
 export type { PriceLineOptions } from './core/price-line';
 
+// ─── CSS Theme ──────────────────────────────────────────────────────
+export { CSS_VARS, readCSSTheme, generateCSSTheme, applyCSSTheme } from './core/css-theme';
+
 // ─── Data Feed ──────────────────────────────────────────────────────
 export { DataFeedManager } from './core/data-feed';
 export type { IDataFeed, DataFeedManagerOptions } from './core/data-feed';

--- a/tests/core/css-theme.test.ts
+++ b/tests/core/css-theme.test.ts
@@ -1,0 +1,86 @@
+import { describe, it, expect } from 'vitest';
+import { CSS_VARS, generateCSSTheme, applyCSSTheme, readCSSTheme } from '@/core/css-theme';
+import { DARK_THEME, LIGHT_THEME } from '@/api/options';
+
+describe('CSS_VARS', () => {
+  it('all variable names are prefixed with --fc-', () => {
+    for (const value of Object.values(CSS_VARS)) {
+      expect(value).toMatch(/^--fc-/);
+    }
+  });
+});
+
+describe('generateCSSTheme', () => {
+  it('generates CSS string from dark theme', () => {
+    const css = generateCSSTheme(DARK_THEME);
+    expect(css).toContain('--fc-bg: #1a1a2e');
+    expect(css).toContain('--fc-text: #d1d4dc');
+    expect(css).toContain('--fc-crosshair-vert-color: #758696');
+  });
+
+  it('generates CSS string from light theme', () => {
+    const css = generateCSSTheme(LIGHT_THEME);
+    expect(css).toContain('--fc-bg: #ffffff');
+    expect(css).toContain('--fc-text: #333333');
+  });
+
+  it('returns empty string for empty options', () => {
+    const css = generateCSSTheme({});
+    expect(css).toBe('');
+  });
+
+  it('includes only provided properties', () => {
+    const css = generateCSSTheme({ layout: { backgroundColor: '#000' } });
+    expect(css).toContain('--fc-bg: #000');
+    expect(css).not.toContain('--fc-text');
+  });
+});
+
+describe('applyCSSTheme', () => {
+  it('sets CSS custom properties on element', () => {
+    const el = document.createElement('div');
+    applyCSSTheme(el, DARK_THEME);
+    expect(el.style.getPropertyValue('--fc-bg')).toBe('#1a1a2e');
+    expect(el.style.getPropertyValue('--fc-text')).toBe('#d1d4dc');
+  });
+
+  it('sets grid properties', () => {
+    const el = document.createElement('div');
+    applyCSSTheme(el, {
+      grid: { horzLinesColor: 'red', vertLinesColor: 'blue' },
+    });
+    expect(el.style.getPropertyValue('--fc-grid-horz-color')).toBe('red');
+    expect(el.style.getPropertyValue('--fc-grid-vert-color')).toBe('blue');
+  });
+
+  it('does not set properties for undefined values', () => {
+    const el = document.createElement('div');
+    applyCSSTheme(el, {});
+    expect(el.style.getPropertyValue('--fc-bg')).toBe('');
+  });
+});
+
+describe('readCSSTheme', () => {
+  it('reads back properties set via applyCSSTheme', () => {
+    const el = document.createElement('div');
+    document.body.appendChild(el);
+    applyCSSTheme(el, DARK_THEME);
+
+    const theme = readCSSTheme(el);
+    expect(theme.layout?.backgroundColor).toBe('#1a1a2e');
+    expect(theme.layout?.textColor).toBe('#d1d4dc');
+
+    document.body.removeChild(el);
+  });
+
+  it('returns empty options when no properties set', () => {
+    const el = document.createElement('div');
+    document.body.appendChild(el);
+
+    const theme = readCSSTheme(el);
+    expect(theme.layout).toBeUndefined();
+    expect(theme.grid).toBeUndefined();
+
+    document.body.removeChild(el);
+  });
+});


### PR DESCRIPTION
## Summary

- Add `CSS_VARS` constant with all `--fc-*` prefixed CSS custom property names
- Add `readCSSTheme(element)`, `generateCSSTheme(options)`, `applyCSSTheme(element, options)`
- Runtime theme switching by changing CSS variables on the container element
- Built-in themes generate corresponding CSS variable sets

Closes #29

## Test plan

- [x] 10 new tests covering variable naming, generation, application, and roundtrip
- [x] All 1300 tests pass
- [x] TypeScript compiles clean, build succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)