### PR TITLE
feat: add replay/playback mode for historical data

### DIFF
--- a/src/core/replay.ts
+++ b/src/core/replay.ts
@@ -2,11 +2,11 @@ import type { Bar, ColumnStore } from './types';
 
 export type ReplaySpeed = 1 | 2 | 5 | 10;
 
-export type ReplayCallback = (event: {
-  type: 'bar' | 'end' | 'pause' | 'resume';
-  barIndex: number;
-  bar?: Bar;
-}) => void;
+export type ReplayBarEvent = { type: 'bar'; barIndex: number; bar: Bar };
+export type ReplayControlEvent = { type: 'pause' | 'resume' | 'end'; barIndex: number };
+export type ReplayEvent = ReplayBarEvent | ReplayControlEvent;
+
+export type ReplayEventCallback = (event: ReplayEvent) => void;
 
 export interface ReplayOptions {
   /** Playback speed multiplier (default: 1). */
@@ -19,7 +19,7 @@ export interface ReplayOptions {
  *
  * Usage:
  *   replay.start(store, fromIndex, { speed: 2 });
- *   replay.onBar(callback); // fired for each revealed bar
+ *   replay.onEvent(callback); // fired for each revealed bar or control event
  *   replay.pause();
  *   replay.stepForward();
  *   replay.resume();
@@ -32,7 +32,7 @@ export class ReplayManager {
   private _speed: ReplaySpeed = 1;
   private _playing = false;
   private _timerId: ReturnType<typeof setInterval> | null = null;
-  private _callbacks: ReplayCallback[] = [];
+  private _callbacks: ReplayEventCallback[] = [];
   private _baseIntervalMs = 500; // 500ms per bar at 1x speed
 
   /** Whether replay is currently active (playing or paused). */
@@ -56,12 +56,12 @@ export class ReplayManager {
   }
 
   /** Subscribe to replay events. */
-  onBar(callback: ReplayCallback): void {
+  onEvent(callback: ReplayEventCallback): void {
     this._callbacks.push(callback);
   }
 
   /** Unsubscribe from replay events. */
-  offBar(callback: ReplayCallback): void {
+  offEvent(callback: ReplayEventCallback): void {
     const idx = this._callbacks.indexOf(callback);
     if (idx >= 0) this._callbacks.splice(idx, 1);
   }
@@ -73,10 +73,20 @@ export class ReplayManager {
    */
   start(store: ColumnStore, fromIndex: number, options?: ReplayOptions): void {
     this.stop();
+    if (store.length === 0) return;
+
     this._store = store;
-    this._currentIndex = Math.max(0, Math.min(fromIndex, store.length - 1));
     this._endIndex = store.length - 1;
+    this._currentIndex = Math.max(0, Math.min(fromIndex, this._endIndex));
     this._speed = options?.speed ?? 1;
+
+    // Don't start playing if already at the end
+    if (this._currentIndex >= this._endIndex) {
+      this._playing = false;
+      this._emit({ type: 'end', barIndex: this._currentIndex });
+      return;
+    }
+
     this._playing = true;
     this._startTimer();
   }
@@ -92,6 +102,8 @@ export class ReplayManager {
   /** Resume playback after pause. */
   resume(): void {
     if (this._playing || !this._store) return;
+    // Don't resume if already at end
+    if (this._currentIndex >= this._endIndex) return;
     this._playing = true;
     this._startTimer();
     this._emit({ type: 'resume', barIndex: this._currentIndex });
@@ -140,6 +152,7 @@ export class ReplayManager {
     const interval = this._baseIntervalMs / this._speed;
     this._timerId = setInterval(() => {
       if (!this.stepForward()) {
+        this._playing = false;
         this._stopTimer();
       }
     }, interval);
@@ -166,7 +179,7 @@ export class ReplayManager {
     this._emit({ type: 'bar', barIndex: i, bar });
   }
 
-  private _emit(event: Parameters<ReplayCallback>[0]): void {
+  private _emit(event: ReplayEvent): void {
     for (const cb of this._callbacks) cb(event);
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -56,7 +56,7 @@ export type { PriceLineOptions } from './core/price-line';
 
 // ─── Replay ─────────────────────────────────────────────────────────
 export { ReplayManager } from './core/replay';
-export type { ReplaySpeed, ReplayCallback, ReplayOptions } from './core/replay';
+export type { ReplaySpeed, ReplayEvent, ReplayBarEvent, ReplayControlEvent, ReplayEventCallback, ReplayOptions } from './core/replay';
 
 // ─── Text Labels ────────────────────────────────────────────────────
 export { TextLabel, createTextLabels } from './core/text-label';

--- a/tests/core/replay.test.ts
+++ b/tests/core/replay.test.ts
@@ -1,14 +1,16 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { ReplayManager } from '@/core/replay';
 import type { ColumnStore } from '@/core/types';
+import type { ReplayEvent } from '@/core/replay';
 
 function makeStore(length: number): ColumnStore {
-  const time = new Float64Array(length);
-  const open = new Float64Array(length);
-  const high = new Float64Array(length);
-  const low = new Float64Array(length);
-  const close = new Float64Array(length);
-  const volume = new Float64Array(length);
+  const capacity = Math.max(length, 1);
+  const time = new Float64Array(capacity);
+  const open = new Float64Array(capacity);
+  const high = new Float64Array(capacity);
+  const low = new Float64Array(capacity);
+  const close = new Float64Array(capacity);
+  const volume = new Float64Array(capacity);
   for (let i = 0; i < length; i++) {
     time[i] = 1000 + i * 60;
     open[i] = 100 + i;
@@ -17,7 +19,7 @@ function makeStore(length: number): ColumnStore {
     close[i] = 105 + i;
     volume[i] = 1000;
   }
-  return { time, open, high, low, close, volume, length };
+  return { time, open, high, low, close, volume, length, capacity };
 }
 
 describe('ReplayManager', () => {
@@ -46,20 +48,22 @@ describe('ReplayManager', () => {
     expect(replay.currentIndex).toBe(2);
   });
 
-  it('steps forward and fires bar callback', () => {
+  it('steps forward and fires bar event with discriminated type', () => {
     const store = makeStore(10);
     const cb = vi.fn();
-    replay.onBar(cb);
+    replay.onEvent(cb);
     replay.start(store, 3);
 
     const stepped = replay.stepForward();
     expect(stepped).toBe(true);
     expect(replay.currentIndex).toBe(4);
-    expect(cb).toHaveBeenCalledWith(expect.objectContaining({
-      type: 'bar',
-      barIndex: 4,
-    }));
-    expect(cb.mock.calls[0][0].bar.time).toBe(store.time[4]);
+
+    const event = cb.mock.calls[0][0] as ReplayEvent;
+    expect(event.type).toBe('bar');
+    if (event.type === 'bar') {
+      expect(event.bar.time).toBe(store.time[4]);
+      expect(event.barIndex).toBe(4);
+    }
   });
 
   it('steps backward', () => {
@@ -78,11 +82,11 @@ describe('ReplayManager', () => {
   it('fires end event when reaching last bar', () => {
     const store = makeStore(5);
     const cb = vi.fn();
-    replay.onBar(cb);
+    replay.onEvent(cb);
     replay.start(store, 3);
 
     replay.stepForward(); // index 4 = last bar
-    const endCall = cb.mock.calls.find((c: unknown[]) => (c[0] as { type: string }).type === 'end');
+    const endCall = cb.mock.calls.find((c: unknown[]) => (c[0] as ReplayEvent).type === 'end');
     expect(endCall).toBeDefined();
     expect(replay.playing).toBe(false);
   });
@@ -90,25 +94,24 @@ describe('ReplayManager', () => {
   it('pauses and resumes', () => {
     const store = makeStore(10);
     const cb = vi.fn();
-    replay.onBar(cb);
+    replay.onEvent(cb);
     replay.start(store, 0);
 
     replay.pause();
     expect(replay.playing).toBe(false);
-    expect(cb).toHaveBeenCalledWith(expect.objectContaining({ type: 'pause' }));
+    const pauseCall = cb.mock.calls.find((c: unknown[]) => (c[0] as ReplayEvent).type === 'pause');
+    expect(pauseCall).toBeDefined();
 
     replay.resume();
     expect(replay.playing).toBe(true);
-    expect(cb).toHaveBeenCalledWith(expect.objectContaining({ type: 'resume' }));
+    const resumeCall = cb.mock.calls.find((c: unknown[]) => (c[0] as ReplayEvent).type === 'resume');
+    expect(resumeCall).toBeDefined();
   });
 
   it('auto-advances via timer at 1x speed', () => {
     const store = makeStore(10);
-    const cb = vi.fn();
-    replay.onBar(cb);
     replay.start(store, 0);
 
-    // At 1x speed, base interval is 500ms
     vi.advanceTimersByTime(500);
     expect(replay.currentIndex).toBe(1);
 
@@ -121,7 +124,6 @@ describe('ReplayManager', () => {
     replay.start(store, 0, { speed: 5 });
     expect(replay.speed).toBe(5);
 
-    // At 5x speed, interval is 500/5 = 100ms
     vi.advanceTimersByTime(100);
     expect(replay.currentIndex).toBe(1);
   });
@@ -133,7 +135,6 @@ describe('ReplayManager', () => {
     replay.setSpeed(10);
     expect(replay.speed).toBe(10);
 
-    // At 10x, interval is 50ms
     vi.advanceTimersByTime(50);
     expect(replay.currentIndex).toBe(1);
   });
@@ -147,13 +148,49 @@ describe('ReplayManager', () => {
     expect(replay.currentIndex).toBe(0);
   });
 
-  it('offBar removes callback', () => {
+  it('offEvent removes callback', () => {
     const store = makeStore(10);
     const cb = vi.fn();
-    replay.onBar(cb);
-    replay.offBar(cb);
+    replay.onEvent(cb);
+    replay.offEvent(cb);
     replay.start(store, 0);
     replay.stepForward();
     expect(cb).not.toHaveBeenCalled();
+  });
+
+  // Edge cases from review
+  it('does not start playing when fromIndex is at last bar', () => {
+    const store = makeStore(5);
+    const cb = vi.fn();
+    replay.onEvent(cb);
+    replay.start(store, 4); // last bar
+    expect(replay.playing).toBe(false);
+    expect(cb).toHaveBeenCalledWith(expect.objectContaining({ type: 'end' }));
+  });
+
+  it('handles empty store gracefully', () => {
+    const store = makeStore(0);
+    replay.start(store, 0);
+    expect(replay.active).toBe(false);
+    expect(replay.playing).toBe(false);
+  });
+
+  it('resume does nothing when already at end', () => {
+    const store = makeStore(5);
+    replay.start(store, 3);
+    replay.stepForward(); // reaches end
+    expect(replay.playing).toBe(false);
+    replay.resume();
+    expect(replay.playing).toBe(false); // should not resume
+  });
+
+  it('timer sets playing=false when stepForward fails', () => {
+    const store = makeStore(3);
+    replay.start(store, 1);
+
+    // Advance timer: index 1→2 (last bar, end fires, playing=false)
+    vi.advanceTimersByTime(500);
+    expect(replay.currentIndex).toBe(2);
+    expect(replay.playing).toBe(false);
   });
 });


### PR DESCRIPTION
## Summary

- Add `ReplayManager` with start/pause/resume/stepForward/stepBackward/stop controls
- Speed multiplier: 1x, 2x, 5x, 10x (configurable at start or runtime)
- Event callbacks: bar revealed, pause, resume, end-of-data
- Timer-based auto-advance with proper cleanup

Closes #38

## Test plan

- [x] 12 new tests covering start, step, pause/resume, speed, timer, end event, cleanup
- [x] All 1353 tests pass, TypeScript clean, build succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)