### PR TITLE
docs: add Storybook documentation for all new features

### DIFF
--- a/stories/Docs/Accessibility.mdx
+++ b/stories/Docs/Accessibility.mdx
@@ -1,0 +1,124 @@
+import { Meta } from '@storybook/addon-docs/blocks';
+
+<Meta title="Docs/Accessibility" />
+
+# Accessibility
+
+fin-charter includes built-in accessibility support through the `ChartAccessibility` class, providing ARIA live regions for screen-reader announcements and keyboard navigation for chart data.
+
+## `ChartAccessibility`
+
+```ts
+import { ChartAccessibility } from 'fin-charter/core/accessibility';
+
+const a11y = new ChartAccessibility();
+```
+
+### ARIA Live Region
+
+Create a hidden ARIA live region inside the chart container. Screen readers monitor this region and announce changes automatically.
+
+```ts
+const region = a11y.createAriaLiveRegion(chartContainer);
+// The region is a visually-hidden <div> with:
+//   role="status"
+//   aria-live="polite"
+//   aria-atomic="true"
+```
+
+The chart container also receives `role="img"` if no role is already set.
+
+### Price Announcements
+
+Announce the current price and change to screen readers:
+
+```ts
+// When crosshair moves to a new bar
+a11y.announcePrice(185.50, -2.30);
+// Screen reader: "Price 185.50, down 2.30"
+
+a11y.announcePrice(190.00, 4.50);
+// Screen reader: "Price 190.00, up 4.50"
+
+a11y.announcePrice(188.00, 0);
+// Screen reader: "Price 188.00, unchanged 0.00"
+```
+
+### Bar Data Announcements
+
+Announce full OHLCV data for the focused bar:
+
+```ts
+a11y.announceBar({
+  time: 1704067200,
+  open: 185.33,
+  high: 186.10,
+  low: 183.79,
+  close: 185.56,
+  volume: 45034200,
+});
+// Screen reader: "January 1, Open 185.33, High 186.10, Low 183.79, Close 185.56, Volume 45,034,200"
+```
+
+---
+
+## Keyboard Navigation
+
+The chart supports keyboard navigation for moving between bars:
+
+| Key | Action |
+|---|---|
+| `Left Arrow` | Move focus to previous bar |
+| `Right Arrow` | Move focus to next bar |
+| `Home` | Jump to first visible bar |
+| `End` | Jump to last visible bar |
+| `Escape` | Clear focus / exit selection mode |
+
+```ts
+// Set the total number of bars for keyboard navigation bounds
+a11y.setTotalBars(data.length);
+
+// Move focus to a specific bar
+a11y.setFocusedBar(50);
+
+// Get the currently focused bar index
+const idx = a11y.focusedBarIndex; // -1 if no bar is focused
+```
+
+---
+
+## Chart Description
+
+Set a descriptive label for the entire chart:
+
+```ts
+a11y.setDescription('AAPL daily candlestick chart showing 200 bars from January 2024');
+// Sets aria-label on the chart container
+```
+
+---
+
+## Lifecycle
+
+```ts
+// Create and attach
+const a11y = new ChartAccessibility();
+a11y.createAriaLiveRegion(container);
+
+// Use during chart lifetime
+a11y.announcePrice(currentPrice, change);
+
+// Clean up when chart is destroyed
+a11y.dispose();
+```
+
+After calling `dispose()`, all methods become no-ops and the ARIA live region is removed from the DOM.
+
+---
+
+## Best Practices
+
+- Always call `createAriaLiveRegion()` after the chart container is in the DOM
+- Use `announcePrice()` on crosshair move for real-time feedback
+- Set a meaningful `description` that includes the symbol, chart type, and time range
+- The `polite` aria-live setting ensures announcements do not interrupt the user

--- a/stories/Docs/CSSTheming.mdx
+++ b/stories/Docs/CSSTheming.mdx
@@ -1,0 +1,136 @@
+import { Meta } from '@storybook/addon-docs/blocks';
+
+<Meta title="Docs/CSS Theming" />
+
+# CSS Theming
+
+fin-charter supports runtime theming through CSS custom properties (CSS variables). This allows themes to be defined in CSS stylesheets and applied without JavaScript configuration.
+
+## CSS Custom Properties
+
+All properties are prefixed with `--fc-` to avoid collisions:
+
+```ts
+import { CSS_VARS } from 'fin-charter';
+```
+
+| Variable | CSS Property | Description |
+|---|---|---|
+| `bg` | `--fc-bg` | Chart background color |
+| `text` | `--fc-text` | Text color for labels |
+| `fontSize` | `--fc-font-size` | Font size (px) |
+| `fontFamily` | `--fc-font-family` | Font family |
+| `gridHorzColor` | `--fc-grid-horz-color` | Horizontal grid line color |
+| `gridVertColor` | `--fc-grid-vert-color` | Vertical grid line color |
+| `crosshairVertColor` | `--fc-crosshair-vert-color` | Crosshair vertical line color |
+| `crosshairHorzColor` | `--fc-crosshair-horz-color` | Crosshair horizontal line color |
+| `candleUpColor` | `--fc-candle-up` | Candle up (bullish) color |
+| `candleDownColor` | `--fc-candle-down` | Candle down (bearish) color |
+| `lineColor` | `--fc-line-color` | Line series color |
+| `areaTopColor` | `--fc-area-top` | Area gradient top color |
+| `areaBottomColor` | `--fc-area-bottom` | Area gradient bottom color |
+| `areaLineColor` | `--fc-area-line` | Area line color |
+| `volumeUpColor` | `--fc-volume-up` | Volume up bar color |
+| `volumeDownColor` | `--fc-volume-down` | Volume down bar color |
+| `watermarkColor` | `--fc-watermark-color` | Watermark text color |
+
+---
+
+## Defining a Theme in CSS
+
+```css
+.chart-dark {
+  --fc-bg: #1a1a2e;
+  --fc-text: #d1d4dc;
+  --fc-font-size: 11;
+  --fc-grid-horz-color: rgba(255, 255, 255, 0.06);
+  --fc-grid-vert-color: rgba(255, 255, 255, 0.06);
+  --fc-crosshair-vert-color: #9598A1;
+  --fc-crosshair-horz-color: #9598A1;
+  --fc-candle-up: #26a69a;
+  --fc-candle-down: #ef5350;
+  --fc-volume-up: rgba(38, 166, 154, 0.5);
+  --fc-volume-down: rgba(239, 83, 80, 0.5);
+  --fc-watermark-color: rgba(255, 255, 255, 0.04);
+}
+
+.chart-light {
+  --fc-bg: #ffffff;
+  --fc-text: #333333;
+  --fc-grid-horz-color: rgba(0, 0, 0, 0.06);
+  --fc-grid-vert-color: rgba(0, 0, 0, 0.06);
+  --fc-candle-up: #089981;
+  --fc-candle-down: #f23645;
+}
+```
+
+---
+
+## Reading a CSS Theme
+
+Use `readCSSTheme()` to read the computed CSS variables from a container element and convert them into `ChartOptions`:
+
+```ts
+import { readCSSTheme, createChart } from 'fin-charter';
+
+const container = document.getElementById('chart')!;
+container.classList.add('chart-dark');
+
+const themeOptions = readCSSTheme(container);
+const chart = createChart(container, {
+  autoSize: true,
+  ...themeOptions,
+});
+```
+
+Only variables that are defined in CSS are included in the result. Undefined variables are omitted so they do not override defaults.
+
+---
+
+## Generating CSS from Options
+
+Convert a `ChartOptions` object into a CSS custom properties string:
+
+```ts
+import { generateCSSTheme, DARK_THEME } from 'fin-charter';
+
+const css = generateCSSTheme(DARK_THEME);
+// Returns: "--fc-bg: #1a1a2e; --fc-text: #d1d4dc; ..."
+```
+
+---
+
+## Applying a CSS Theme at Runtime
+
+Apply CSS variables directly to a container element:
+
+```ts
+import { applyCSSTheme, LIGHT_THEME } from 'fin-charter';
+
+applyCSSTheme(container, LIGHT_THEME);
+// Sets all --fc-* properties on the container's style
+
+// Then re-read and apply to chart
+const opts = readCSSTheme(container);
+chart.applyOptions(opts);
+```
+
+---
+
+## Switching Themes Dynamically
+
+```ts
+function setTheme(theme: 'dark' | 'light') {
+  container.className = theme === 'dark' ? 'chart-dark' : 'chart-light';
+  const opts = readCSSTheme(container);
+  chart.applyOptions(opts);
+}
+
+// Toggle with a button
+document.getElementById('theme-toggle')!.addEventListener('click', () => {
+  const isDark = container.classList.contains('chart-dark');
+  setTheme(isDark ? 'light' : 'dark');
+});
+```
+
+This approach keeps theme definitions in CSS where designers can work with them, while the chart reads the computed values at runtime.

--- a/stories/Docs/ChartSync.mdx
+++ b/stories/Docs/ChartSync.mdx
@@ -1,0 +1,132 @@
+import { Meta } from '@storybook/addon-docs/blocks';
+
+<Meta title="Docs/Chart Sync" />
+
+# Chart Sync
+
+Synchronize multiple chart instances so that crosshair movement and time-scale panning/zooming on one chart is mirrored to all others in the group.
+
+## `ChartSyncGroup`
+
+```ts
+import { ChartSyncGroup } from 'fin-charter/core/chart-sync';
+
+const group = new ChartSyncGroup();
+group.addChart(chart1);
+group.addChart(chart2);
+group.addChart(chart3);
+
+// Enable crosshair synchronization
+group.syncCrosshair();
+
+// Enable time-scale synchronization (zoom/pan)
+group.syncTimeScale();
+```
+
+When the user moves the crosshair on `chart1`, the same time/price position is shown on `chart2` and `chart3`. When the user pans or zooms `chart1`, all charts follow.
+
+---
+
+## Interfaces
+
+### `ISyncableChart`
+
+The minimal chart interface required for synchronization:
+
+```ts
+interface ISyncableChart {
+  subscribeCrosshairMove(cb: (state: SyncCrosshairState | null) => void): void;
+  unsubscribeCrosshairMove(cb: (state: SyncCrosshairState | null) => void): void;
+  subscribeVisibleRangeChange(cb: (range: { from: number; to: number } | null) => void): void;
+  unsubscribeVisibleRangeChange(cb: (range: { from: number; to: number } | null) => void): void;
+  setVisibleRange(from: number, to: number): void;
+}
+```
+
+### `SyncCrosshairState`
+
+```ts
+interface SyncCrosshairState {
+  time: number;
+  price: number;
+  x: number;
+  y: number;
+  barIndex: number;
+}
+```
+
+---
+
+## Crosshair Sync
+
+When enabled, moving the crosshair on any chart in the group broadcasts the position to all other charts:
+
+```ts
+group.syncCrosshair();
+
+// Listen for sync events
+group.onCrosshairSync((sourceChart, state) => {
+  console.log('Crosshair moved on source chart to time:', state?.time);
+});
+```
+
+The sync uses guard flags to prevent re-entrant loops (chart A triggers chart B which triggers chart A).
+
+---
+
+## Time-Scale Sync
+
+When enabled, panning or zooming on any chart updates the visible range on all other charts:
+
+```ts
+group.syncTimeScale();
+
+// Listen for sync events
+group.onTimeScaleSync((sourceChart, range) => {
+  console.log('Visible range changed:', range.from, 'to', range.to);
+});
+```
+
+---
+
+## Managing Charts
+
+```ts
+// Add a chart to the group
+group.addChart(newChart);
+
+// Remove a chart from the group
+group.removeChart(oldChart);
+
+// Dispose the entire group (unsubscribes all listeners)
+group.dispose();
+```
+
+---
+
+## Example: Multi-Symbol Dashboard
+
+```ts
+import { createChart } from 'fin-charter';
+import { ChartSyncGroup } from 'fin-charter/core/chart-sync';
+
+const syncGroup = new ChartSyncGroup();
+
+const symbols = ['AAPL', 'GOOGL', 'MSFT'];
+const charts = symbols.map((symbol) => {
+  const container = document.createElement('div');
+  container.style.height = '300px';
+  document.getElementById('dashboard')!.appendChild(container);
+
+  const chart = createChart(container, { autoSize: true, symbol });
+  const series = chart.addSeries({ type: 'candlestick' });
+  // ... load data for each symbol
+
+  syncGroup.addChart(chart);
+  return chart;
+});
+
+// Sync all charts
+syncGroup.syncCrosshair();
+syncGroup.syncTimeScale();
+```

--- a/stories/Docs/CustomIndicators.mdx
+++ b/stories/Docs/CustomIndicators.mdx
@@ -1,0 +1,151 @@
+import { Meta } from '@storybook/addon-docs/blocks';
+
+<Meta title="Docs/Custom Indicators" />
+
+# Custom Indicators
+
+Register your own indicator types that appear alongside built-in indicators. Custom indicators receive raw `ColumnStore` data and return computed output arrays.
+
+## `CustomIndicatorRegistry`
+
+```ts
+import { CustomIndicatorRegistry } from 'fin-charter';
+
+const registry = new CustomIndicatorRegistry();
+
+registry.register({
+  name: 'vwap-bands',
+  label: 'VWAP Bands',
+  overlay: true,
+  params: [
+    { name: 'multiplier', defaultValue: 2, min: 0.5, max: 5, step: 0.5 },
+  ],
+  outputs: [
+    { name: 'vwap', color: '#FF9800', style: 'line' },
+    { name: 'upper', color: '#26a69a', style: 'line' },
+    { name: 'lower', color: '#ef5350', style: 'line' },
+  ],
+  compute: (store, params) => {
+    const len = store.length;
+    const vwap = new Float64Array(len);
+    const upper = new Float64Array(len);
+    const lower = new Float64Array(len);
+
+    let cumVolume = 0;
+    let cumTPV = 0;     // cumulative typical-price * volume
+    let cumTPV2 = 0;    // cumulative (typical-price^2) * volume
+
+    for (let i = 0; i < len; i++) {
+      const tp = (store.high[i] + store.low[i] + store.close[i]) / 3;
+      const vol = store.volume[i];
+      cumVolume += vol;
+      cumTPV += tp * vol;
+      cumTPV2 += tp * tp * vol;
+
+      const v = cumVolume > 0 ? cumTPV / cumVolume : tp;
+      const variance = cumVolume > 0
+        ? (cumTPV2 / cumVolume) - v * v
+        : 0;
+      const stdDev = Math.sqrt(Math.max(0, variance));
+
+      vwap[i] = v;
+      upper[i] = v + params.multiplier * stdDev;
+      lower[i] = v - params.multiplier * stdDev;
+    }
+
+    return new Map([
+      ['vwap', vwap],
+      ['upper', upper],
+      ['lower', lower],
+    ]);
+  },
+});
+```
+
+---
+
+## Interfaces
+
+### `CustomIndicatorDescriptor`
+
+```ts
+interface CustomIndicatorDescriptor {
+  name: string;           // Unique identifier
+  label: string;          // Display name for UI
+  overlay: boolean;       // true = overlays on price chart, false = separate pane
+  params: IndicatorParam[];
+  outputs: IndicatorOutput[];
+  compute: IndicatorComputeFn;
+}
+```
+
+### `IndicatorParam`
+
+```ts
+interface IndicatorParam {
+  name: string;
+  defaultValue: number;
+  min?: number;
+  max?: number;
+  step?: number;
+}
+```
+
+### `IndicatorOutput`
+
+```ts
+interface IndicatorOutput {
+  name: string;
+  color?: string;
+  style?: 'line' | 'histogram' | 'dots' | 'area';
+}
+```
+
+### `IndicatorComputeFn`
+
+```ts
+type IndicatorComputeFn = (
+  store: ColumnStore,
+  params: Record<string, number>,
+) => Map<string, Float64Array>;
+```
+
+The compute function receives the full `ColumnStore` and a map of parameter name to value. It returns a `Map` where each key matches an output name and each value is a `Float64Array` aligned with the store's bar indices.
+
+---
+
+## Registry Methods
+
+```ts
+const registry = new CustomIndicatorRegistry();
+
+// Register a custom indicator
+registry.register(descriptor);
+
+// Unregister
+registry.unregister('vwap-bands');
+
+// Get a descriptor by name
+const desc = registry.get('vwap-bands');
+
+// List all registered indicators
+const all = registry.getAll();
+
+// Check if registered
+registry.has('vwap-bands'); // true
+```
+
+---
+
+## Using with the Chart
+
+Once registered, custom indicators can be added to charts like built-in indicators:
+
+```ts
+const chart = createChart(container, { autoSize: true });
+const series = chart.addSeries({ type: 'candlestick' });
+series.setData(data);
+
+// Add the custom indicator (assumes registry is configured on the chart)
+chart.addIndicator('vwap-bands', { multiplier: 2 });
+```

--- a/stories/Docs/DataFeed.mdx
+++ b/stories/Docs/DataFeed.mdx
@@ -1,0 +1,161 @@
+import { Meta } from '@storybook/addon-docs/blocks';
+
+<Meta title="Docs/Data Feed" />
+
+# Data Feed
+
+fin-charter provides a data feed abstraction for loading historical bars with pagination, caching, and real-time streaming.
+
+## `IDataFeed` Interface
+
+```ts
+interface IDataFeed {
+  getBars(
+    symbol: string,
+    resolution: string,
+    from: number,
+    to: number,
+  ): Promise<Bar[]>;
+}
+```
+
+Implement `getBars()` to fetch OHLCV data from your backend. The chart calls this when the user scrolls to the edge and more historical data is needed.
+
+---
+
+## `DataFeedManager`
+
+Wraps an `IDataFeed` with request deduplication, local caching, and loading state tracking.
+
+```ts
+import { DataFeedManager } from 'fin-charter';
+import type { IDataFeed } from 'fin-charter';
+
+class MyDataFeed implements IDataFeed {
+  async getBars(symbol: string, resolution: string, from: number, to: number) {
+    const response = await fetch(
+      `/api/bars?symbol=${symbol}&resolution=${resolution}&from=${from}&to=${to}`
+    );
+    return response.json();
+  }
+}
+
+const manager = new DataFeedManager(new MyDataFeed(), {
+  maxCacheEntries: 100,
+});
+
+// Fetches from network on first call, serves from cache on subsequent calls
+const bars = await manager.getBars('AAPL', 'D', 1704067200, 1709078400);
+console.log('Loading:', manager.loading);
+```
+
+### Options
+
+| Option | Type | Default | Description |
+|---|---|---|---|
+| `maxCacheEntries` | `number` | `100` | Max cached range entries per symbol+resolution |
+
+---
+
+## Streaming Adapters
+
+For real-time data, use the `IStreamingAdapter` interface:
+
+```ts
+interface IStreamingAdapter {
+  connect(): void;
+  disconnect(): void;
+  subscribeBars(symbol: string, resolution: string, onBar: (bar: Bar) => void): void;
+  unsubscribeBars(symbol: string, resolution: string): void;
+}
+```
+
+### `WebSocketAdapter`
+
+Streams bar data over WebSocket with automatic reconnection and exponential backoff.
+
+```ts
+import { WebSocketAdapter } from 'fin-charter';
+
+const ws = new WebSocketAdapter({
+  url: 'wss://stream.example.com/bars',
+  reconnect: true,
+  maxReconnectAttempts: 10,
+  reconnectDelay: 1000,
+  maxReconnectDelay: 30000,
+  parseMessage: (data) => {
+    const msg = JSON.parse(data as string);
+    return {
+      symbol: msg.s,
+      resolution: msg.r,
+      bar: { time: msg.t, open: msg.o, high: msg.h, low: msg.l, close: msg.c, volume: msg.v },
+    };
+  },
+});
+
+ws.connect();
+ws.subscribeBars('AAPL', 'D', (bar) => {
+  series.update(bar);
+});
+```
+
+### `PollingAdapter`
+
+Polls a REST endpoint at a fixed interval for environments without WebSocket support.
+
+```ts
+import { PollingAdapter } from 'fin-charter';
+
+const poller = new PollingAdapter({
+  url: 'https://api.example.com/latest',
+  interval: 5000, // 5 seconds
+  parseResponse: (data) => ({
+    symbol: data.symbol,
+    resolution: 'D',
+    bar: data.bar,
+  }),
+});
+
+poller.connect();
+poller.subscribeBars('AAPL', 'D', (bar) => series.update(bar));
+```
+
+### `TickBuffer`
+
+Buffers incoming ticks and flushes them as OHLCV bars at configurable intervals:
+
+```ts
+import { TickBuffer } from 'fin-charter';
+
+const buffer = new TickBuffer({
+  flushIntervalMs: 1000,
+  onBar: (bar) => series.update(bar),
+});
+
+// Push individual trades/ticks
+buffer.push({ price: 185.50, volume: 100 });
+buffer.push({ price: 185.55, volume: 200 });
+// After 1 second, a consolidated bar is flushed to onBar
+```
+
+---
+
+## Full Integration Example
+
+```ts
+import { createChart, DataFeedManager, WebSocketAdapter } from 'fin-charter';
+
+const feed = new DataFeedManager(myDataFeed);
+const ws = new WebSocketAdapter({ url: 'wss://...' });
+
+const chart = createChart(container, { autoSize: true, symbol: 'AAPL' });
+const series = chart.addSeries({ type: 'candlestick' });
+
+// Load historical data
+const bars = await feed.getBars('AAPL', 'D', from, to);
+series.setData(bars);
+
+// Stream real-time updates
+ws.connect();
+ws.subscribeBars('AAPL', 'D', (bar) => series.update(bar));
+```

--- a/stories/Docs/PluginSystem.mdx
+++ b/stories/Docs/PluginSystem.mdx
@@ -1,0 +1,233 @@
+import { Meta } from '@storybook/addon-docs/blocks';
+
+<Meta title="Docs/Plugin System" />
+
+# Plugin System
+
+fin-charter provides a formal plugin system through the `IPlugin` interface and `PluginManager`. Plugins can add custom series types, indicators, drawing tools, UI panels, and intercept chart events with full lifecycle management and dependency resolution.
+
+## `IPlugin` Interface
+
+```ts
+interface IPlugin {
+  readonly name: string;
+  readonly version?: string;
+  readonly dependencies?: string[];
+
+  install(chart: PluginChartApi): void;
+  uninstall?(): void;
+  onPaint?(context: PluginPaintContext): void;
+  onOptionsChange?(options: Record<string, unknown>): void;
+  onDataUpdate?(): void;
+}
+```
+
+### Lifecycle Hooks
+
+| Hook | When Called |
+|---|---|
+| `install(chart)` | When `chart.use(plugin)` is called |
+| `uninstall()` | When the plugin is removed or the chart is destroyed |
+| `onPaint(context)` | After each paint cycle, after all series are rendered |
+| `onOptionsChange(options)` | When `chart.applyOptions()` is called |
+| `onDataUpdate()` | When any series data changes |
+
+---
+
+## `PluginChartApi`
+
+The subset of the chart API exposed to plugins:
+
+```ts
+interface PluginChartApi {
+  getContainer(): HTMLElement;
+  requestRepaint(): void;
+  getSize(): { width: number; height: number };
+}
+```
+
+---
+
+## `PluginPaintContext`
+
+Context passed to the `onPaint` hook:
+
+```ts
+interface PluginPaintContext {
+  ctx: CanvasRenderingContext2D;
+  width: number;
+  height: number;
+  pixelRatio: number;
+}
+```
+
+---
+
+## `PluginManager`
+
+Manages plugin lifecycle, dependency resolution, and event dispatch.
+
+```ts
+import { PluginManager } from 'fin-charter';
+
+const manager = new PluginManager();
+manager.setChartApi(chartApi);
+```
+
+### Installing Plugins
+
+```ts
+manager.use(myPlugin);
+```
+
+Dependencies are resolved at install time. If a plugin declares dependencies, they must already be installed:
+
+```ts
+const basePlugin: IPlugin = {
+  name: 'base-plugin',
+  install(chart) { /* ... */ },
+};
+
+const dependentPlugin: IPlugin = {
+  name: 'dependent-plugin',
+  dependencies: ['base-plugin'],
+  install(chart) { /* ... */ },
+};
+
+manager.use(basePlugin);      // OK
+manager.use(dependentPlugin); // OK, base-plugin is installed
+
+// This would throw:
+// manager.use(dependentPlugin); // Error: depends on 'base-plugin' which is not installed
+```
+
+### Removing Plugins
+
+```ts
+manager.remove('my-plugin');
+```
+
+### Querying Plugins
+
+```ts
+manager.has('my-plugin');     // true/false
+manager.get('my-plugin');     // IPlugin | undefined
+manager.getAll();             // IPlugin[]
+```
+
+### Dispatching Events
+
+```ts
+// Called by the chart internally:
+manager.notifyPaint(paintContext);
+manager.notifyOptionsChange(options);
+manager.notifyDataUpdate();
+```
+
+### Cleanup
+
+```ts
+manager.dispose(); // Calls uninstall() on all plugins in reverse order
+```
+
+---
+
+## Example: Watermark Plugin
+
+```ts
+import type { IPlugin, PluginChartApi, PluginPaintContext } from 'fin-charter';
+
+class WatermarkPlugin implements IPlugin {
+  readonly name = 'watermark';
+  readonly version = '1.0.0';
+
+  private _text: string;
+  private _color: string;
+
+  constructor(text: string, color = 'rgba(255, 255, 255, 0.04)') {
+    this._text = text;
+    this._color = color;
+  }
+
+  install(chart: PluginChartApi): void {
+    chart.requestRepaint();
+  }
+
+  onPaint(context: PluginPaintContext): void {
+    const { ctx, width, height, pixelRatio } = context;
+    ctx.save();
+    ctx.fillStyle = this._color;
+    ctx.font = `${Math.round(48 * pixelRatio)}px sans-serif`;
+    ctx.textAlign = 'center';
+    ctx.textBaseline = 'middle';
+    ctx.fillText(
+      this._text,
+      Math.round(width * pixelRatio / 2),
+      Math.round(height * pixelRatio / 2),
+    );
+    ctx.restore();
+  }
+
+  uninstall(): void {
+    // Clean up if needed
+  }
+}
+
+// Usage
+chart.use(new WatermarkPlugin('CONFIDENTIAL'));
+```
+
+---
+
+## Example: Analytics Plugin with Dependencies
+
+```ts
+class AnalyticsPlugin implements IPlugin {
+  readonly name = 'analytics';
+  readonly version = '1.0.0';
+  readonly dependencies = ['base-plugin'];
+
+  private _events: Array<{ type: string; timestamp: number }> = [];
+
+  install(_chart: PluginChartApi): void {
+    console.log('Analytics plugin installed');
+  }
+
+  onOptionsChange(options: Record<string, unknown>): void {
+    this._events.push({ type: 'options-change', timestamp: Date.now() });
+  }
+
+  onDataUpdate(): void {
+    this._events.push({ type: 'data-update', timestamp: Date.now() });
+  }
+
+  getEvents() {
+    return [...this._events];
+  }
+
+  uninstall(): void {
+    console.log(`Analytics: ${this._events.length} events recorded`);
+  }
+}
+```
+
+---
+
+## Relationship to Primitives
+
+The plugin system complements the existing `ISeriesPrimitive` and `IPanePrimitive` interfaces (documented in the [Plugins page](?path=/docs/docs-plugins--docs)):
+
+- **Primitives** are for rendering custom overlays attached to a specific series or pane
+- **Plugins** (IPlugin) are for broader chart extensions with lifecycle management, dependency tracking, and cross-cutting concerns
+
+A plugin can internally create and manage primitives:
+
+```ts
+class MyPlugin implements IPlugin {
+  readonly name = 'my-plugin';
+
+  install(chart: PluginChartApi): void {
+    // Create primitives, register event handlers, etc.
+  }
+}
+```

--- a/stories/Docs/RTLSupport.mdx
+++ b/stories/Docs/RTLSupport.mdx
@@ -1,0 +1,132 @@
+import { Meta } from '@storybook/addon-docs/blocks';
+
+<Meta title="Docs/RTL Support" />
+
+# RTL Support
+
+fin-charter provides right-to-left (RTL) layout support for Arabic, Hebrew, Persian, Urdu, and other RTL scripts. The RTL utilities handle direction detection, coordinate mirroring, and text alignment.
+
+## Direction Detection
+
+```ts
+import { detectDirection } from 'fin-charter';
+
+detectDirection('ar');    // 'rtl' (Arabic)
+detectDirection('he');    // 'rtl' (Hebrew)
+detectDirection('fa');    // 'rtl' (Persian)
+detectDirection('ur');    // 'rtl' (Urdu)
+detectDirection('en');    // 'ltr' (English)
+detectDirection('de');    // 'ltr' (German)
+detectDirection('ja');    // 'ltr' (Japanese)
+```
+
+### Supported RTL Languages
+
+| Code | Language |
+|---|---|
+| `ar` | Arabic |
+| `he` | Hebrew |
+| `fa` | Persian |
+| `ur` | Urdu |
+| `ps` | Pashto |
+| `sd` | Sindhi |
+| `yi` | Yiddish |
+| `dv` | Divehi |
+| `ckb` | Central Kurdish (Sorani) |
+| `ug` | Uyghur |
+
+---
+
+## `TextDirection` Type
+
+```ts
+type TextDirection = 'ltr' | 'rtl';
+```
+
+---
+
+## Coordinate Mirroring
+
+In RTL mode, X coordinates are mirrored so that `x=0` becomes `x=width`:
+
+```ts
+import { mirrorX } from 'fin-charter';
+
+const chartWidth = 800;
+
+// In LTR mode, no change
+mirrorX(100, chartWidth, false); // 100
+
+// In RTL mode, mirrored
+mirrorX(100, chartWidth, true);  // 700
+mirrorX(0, chartWidth, true);    // 800
+mirrorX(800, chartWidth, true);  // 0
+```
+
+This is used internally to flip the price axis from right to left and mirror all horizontal positioning.
+
+---
+
+## Text Alignment
+
+Resolve logical `start`/`end` alignment to physical `left`/`right`:
+
+```ts
+import { resolveTextAlign } from 'fin-charter';
+
+resolveTextAlign('start', false); // 'left'  (LTR)
+resolveTextAlign('start', true);  // 'right' (RTL)
+resolveTextAlign('end', false);   // 'right' (LTR)
+resolveTextAlign('end', true);    // 'left'  (RTL)
+```
+
+---
+
+## Enabling RTL in a Chart
+
+```ts
+import { createChart, detectDirection } from 'fin-charter';
+
+const locale = 'ar'; // Arabic
+const direction = detectDirection(locale);
+
+const chart = createChart(container, {
+  autoSize: true,
+  locale,
+  direction, // 'rtl'
+});
+```
+
+When `direction` is `'rtl'`:
+
+- The price axis moves to the left side
+- The time axis reads right-to-left
+- Tooltips and context menus are mirrored
+- Drawing tool anchor points are mirrored
+- Text labels use RTL text alignment
+
+---
+
+## Dynamic Direction Switching
+
+```ts
+function setLocale(locale: string) {
+  const direction = detectDirection(locale);
+  chart.applyOptions({ locale, direction });
+}
+
+// Switch to Arabic
+setLocale('ar');
+
+// Switch back to English
+setLocale('en');
+```
+
+---
+
+## Best Practices
+
+- Use `detectDirection()` rather than hardcoding direction, so the chart adapts to any locale
+- Test with both LTR and RTL locales to ensure layouts do not break
+- Custom plugins should use `mirrorX()` and `resolveTextAlign()` for RTL compatibility
+- The `direction` option affects all panes and overlays in the chart

--- a/stories/Docs/ReplayMode.mdx
+++ b/stories/Docs/ReplayMode.mdx
@@ -1,0 +1,156 @@
+import { Meta } from '@storybook/addon-docs/blocks';
+
+<Meta title="Docs/Replay Mode" />
+
+# Replay Mode
+
+The `ReplayManager` steps through historical data bar-by-bar to simulate live data streaming. Bars appear progressively as if in real-time, which is useful for backtesting visualization and trading practice.
+
+## `ReplayManager`
+
+```ts
+import { ReplayManager } from 'fin-charter';
+
+const replay = new ReplayManager();
+```
+
+---
+
+## Starting Replay
+
+```ts
+// Start replay from bar index 50 at 2x speed
+replay.start(store, 50, { speed: 2 });
+
+// Bars 0-50 are initially visible
+// Bars 51+ are revealed progressively
+```
+
+### `ReplayOptions`
+
+```ts
+interface ReplayOptions {
+  speed?: ReplaySpeed; // 1 | 2 | 5 | 10
+}
+```
+
+The base interval is 500ms per bar at 1x speed. At 2x, bars appear every 250ms.
+
+---
+
+## Playback Controls
+
+```ts
+// Pause playback
+replay.pause();
+
+// Resume playback
+replay.resume();
+
+// Step forward one bar while paused
+replay.stepForward();
+
+// Stop replay entirely
+replay.stop();
+```
+
+### State Properties
+
+```ts
+replay.active;        // true when replay is running (playing or paused)
+replay.playing;       // true when actively playing (not paused)
+replay.currentIndex;  // current bar index
+replay.speed;         // current speed multiplier
+```
+
+---
+
+## Events
+
+Subscribe to replay events for each revealed bar or control action:
+
+```ts
+replay.onEvent((event) => {
+  switch (event.type) {
+    case 'bar':
+      // A new bar was revealed
+      series.update(event.bar);
+      console.log('Bar', event.barIndex, 'revealed');
+      break;
+    case 'pause':
+      console.log('Replay paused at bar', event.barIndex);
+      break;
+    case 'resume':
+      console.log('Replay resumed at bar', event.barIndex);
+      break;
+    case 'end':
+      console.log('Replay finished at bar', event.barIndex);
+      break;
+  }
+});
+```
+
+### Event Types
+
+```ts
+type ReplayBarEvent = { type: 'bar'; barIndex: number; bar: Bar };
+type ReplayControlEvent = { type: 'pause' | 'resume' | 'end'; barIndex: number };
+type ReplayEvent = ReplayBarEvent | ReplayControlEvent;
+```
+
+### Unsubscribing
+
+```ts
+const handler = (event: ReplayEvent) => { /* ... */ };
+replay.onEvent(handler);
+replay.offEvent(handler);
+```
+
+---
+
+## Speed Control
+
+```ts
+type ReplaySpeed = 1 | 2 | 5 | 10;
+```
+
+| Speed | Interval per bar |
+|---|---|
+| `1` | 500ms |
+| `2` | 250ms |
+| `5` | 100ms |
+| `10` | 50ms |
+
+---
+
+## Full Example
+
+```ts
+import { createChart, ReplayManager } from 'fin-charter';
+
+const chart = createChart(container, { autoSize: true, symbol: 'AAPL' });
+const series = chart.addSeries({ type: 'candlestick' });
+
+// Load all historical data
+series.setData(allBars.slice(0, 50)); // Show first 50 bars
+
+const replay = new ReplayManager();
+
+replay.onEvent((event) => {
+  if (event.type === 'bar') {
+    series.update(event.bar);
+  }
+});
+
+// Start from bar 50 at normal speed
+replay.start(store, 50, { speed: 1 });
+
+// Speed up
+replay.start(store, replay.currentIndex, { speed: 5 });
+
+// Pause and step through manually
+replay.pause();
+replay.stepForward();
+replay.stepForward();
+replay.resume();
+```

--- a/stories/Docs/StorageAdapters.mdx
+++ b/stories/Docs/StorageAdapters.mdx
@@ -1,0 +1,147 @@
+import { Meta } from '@storybook/addon-docs/blocks';
+
+<Meta title="Docs/Storage Adapters" />
+
+# Storage Adapters
+
+fin-charter provides a pluggable storage layer for persisting chart drawings, state, and user preferences. Choose between `LocalStorageAdapter` for small data or `IndexedDBAdapter` for larger datasets.
+
+## `IStorageAdapter` Interface
+
+```ts
+interface IStorageAdapter {
+  save(key: string, state: unknown): Promise<void>;
+  load(key: string): Promise<unknown | null>;
+  delete(key: string): Promise<void>;
+}
+```
+
+All methods are async to support both synchronous (localStorage) and asynchronous (IndexedDB, REST) backends.
+
+---
+
+## `LocalStorageAdapter`
+
+Persists data to browser `localStorage` with an optional key prefix to avoid collisions.
+
+```ts
+import { LocalStorageAdapter } from 'fin-charter';
+
+const storage = new LocalStorageAdapter('fc-');
+
+await storage.save('my-key', { drawings: [...] });
+const data = await storage.load('my-key');
+await storage.delete('my-key');
+```
+
+### Constructor
+
+```ts
+new LocalStorageAdapter(prefix?: string)
+```
+
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `prefix` | `string` | `'fc-'` | Prefix added to all keys in localStorage |
+
+---
+
+## `IndexedDBAdapter`
+
+Persists data to browser `IndexedDB` for larger payloads that exceed localStorage limits.
+
+```ts
+import { IndexedDBAdapter } from 'fin-charter';
+
+const storage = new IndexedDBAdapter('fin-charter', 'chart-state');
+
+await storage.save('drawings:AAPL', serializedDrawings);
+const drawings = await storage.load('drawings:AAPL');
+await storage.delete('drawings:AAPL');
+```
+
+### Constructor
+
+```ts
+new IndexedDBAdapter(dbName?: string, storeName?: string)
+```
+
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `dbName` | `string` | `'fin-charter'` | IndexedDB database name |
+| `storeName` | `string` | `'chart-state'` | Object store name |
+
+---
+
+## `DrawingPersistence`
+
+Manages auto-save and load of drawings per symbol with debouncing to avoid excessive writes.
+
+```ts
+import { DrawingPersistence, LocalStorageAdapter } from 'fin-charter';
+
+const adapter = new LocalStorageAdapter();
+const persistence = new DrawingPersistence(adapter, 500); // 500ms debounce
+
+// Auto-save drawings (debounced)
+persistence.saveDrawings('AAPL', chart.getDrawings());
+
+// Load drawings for a symbol
+const saved = await persistence.loadDrawings('AAPL');
+if (saved) {
+  chart.restoreDrawings(saved);
+}
+
+// Delete all drawings for a symbol
+await persistence.deleteDrawings('AAPL');
+
+// Force flush any pending save
+persistence.flush();
+```
+
+### Constructor
+
+```ts
+new DrawingPersistence(adapter: IStorageAdapter, debounceMs?: number)
+```
+
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `adapter` | `IStorageAdapter` | required | Storage backend |
+| `debounceMs` | `number` | `500` | Debounce delay for save operations |
+
+---
+
+## Custom Storage Backend
+
+Implement `IStorageAdapter` to save to any backend:
+
+```ts
+import type { IStorageAdapter } from 'fin-charter';
+
+class RestStorageAdapter implements IStorageAdapter {
+  constructor(private baseUrl: string) {}
+
+  async save(key: string, state: unknown): Promise<void> {
+    await fetch(`${this.baseUrl}/state/${key}`, {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(state),
+    });
+  }
+
+  async load(key: string): Promise<unknown | null> {
+    const res = await fetch(`${this.baseUrl}/state/${key}`);
+    if (res.status === 404) return null;
+    return res.json();
+  }
+
+  async delete(key: string): Promise<void> {
+    await fetch(`${this.baseUrl}/state/${key}`, { method: 'DELETE' });
+  }
+}
+
+const persistence = new DrawingPersistence(
+  new RestStorageAdapter('https://api.example.com'),
+);
+```

--- a/stories/Docs/SymbolResolver.mdx
+++ b/stories/Docs/SymbolResolver.mdx
@@ -1,0 +1,157 @@
+import { Meta } from '@storybook/addon-docs/blocks';
+
+<Meta title="Docs/Symbol Resolver" />
+
+# Symbol Resolver
+
+The symbol resolver system provides symbol lookup and metadata resolution for chart instances. It supports both custom backends and a built-in in-memory resolver with fuzzy search.
+
+## `ISymbolResolver` Interface
+
+```ts
+interface ISymbolResolver {
+  resolveSymbol(ticker: string): Promise<SymbolInfo>;
+  searchSymbols(query: string, type?: string): Promise<SymbolInfo[]>;
+}
+```
+
+### `SymbolInfo`
+
+```ts
+interface SymbolInfo {
+  symbol: string;          // "AAPL"
+  name: string;            // "Apple Inc."
+  type: string;            // "stock", "crypto", "forex"
+  exchange: string;        // "NASDAQ"
+  timezone: string;        // "America/New_York"
+  pricePrecision: number;  // Decimal places for display (e.g., 2)
+  minMov: number;          // Minimum price movement (e.g., 0.01)
+}
+```
+
+---
+
+## `SimpleSymbolResolver`
+
+An in-memory symbol resolver that uses fuzzy matching on both ticker symbols and human-readable names.
+
+```ts
+import { SimpleSymbolResolver } from 'fin-charter/core/symbol-resolver';
+import type { SymbolInfo } from 'fin-charter/core/symbol-resolver';
+
+const symbols = new Map<string, SymbolInfo>([
+  ['AAPL', {
+    symbol: 'AAPL',
+    name: 'Apple Inc.',
+    type: 'stock',
+    exchange: 'NASDAQ',
+    timezone: 'America/New_York',
+    pricePrecision: 2,
+    minMov: 0.01,
+  }],
+  ['GOOGL', {
+    symbol: 'GOOGL',
+    name: 'Alphabet Inc.',
+    type: 'stock',
+    exchange: 'NASDAQ',
+    timezone: 'America/New_York',
+    pricePrecision: 2,
+    minMov: 0.01,
+  }],
+  ['BTCUSD', {
+    symbol: 'BTCUSD',
+    name: 'Bitcoin / USD',
+    type: 'crypto',
+    exchange: 'Coinbase',
+    timezone: 'Etc/UTC',
+    pricePrecision: 2,
+    minMov: 0.01,
+  }],
+]);
+
+const resolver = new SimpleSymbolResolver(symbols);
+```
+
+### Resolving a Symbol
+
+```ts
+const info = await resolver.resolveSymbol('AAPL');
+// { symbol: 'AAPL', name: 'Apple Inc.', type: 'stock', ... }
+
+try {
+  await resolver.resolveSymbol('INVALID');
+} catch (err) {
+  // "Symbol not found: INVALID"
+}
+```
+
+### Searching Symbols
+
+```ts
+// Search by ticker or name (fuzzy matching)
+const results = await resolver.searchSymbols('app');
+// [{ symbol: 'AAPL', name: 'Apple Inc.', ... }]
+
+// Filter by instrument type
+const cryptoResults = await resolver.searchSymbols('btc', 'crypto');
+// [{ symbol: 'BTCUSD', name: 'Bitcoin / USD', ... }]
+```
+
+---
+
+## Fuzzy Matching
+
+The built-in fuzzy matcher scores results as follows:
+
+| Match Type | Score |
+|---|---|
+| Exact match | 1.0 |
+| Starts with query | 0.9 |
+| Contains query | 0.8 |
+| Characters in order | 0.0 - 0.7 |
+
+Results are sorted by score descending, so exact matches always appear first.
+
+---
+
+## Custom Symbol Resolver
+
+Implement `ISymbolResolver` for your data backend:
+
+```ts
+import type { ISymbolResolver, SymbolInfo } from 'fin-charter/core/symbol-resolver';
+
+class ApiSymbolResolver implements ISymbolResolver {
+  constructor(private baseUrl: string) {}
+
+  async resolveSymbol(ticker: string): Promise<SymbolInfo> {
+    const res = await fetch(`${this.baseUrl}/symbols/${ticker}`);
+    if (!res.ok) throw new Error(`Symbol not found: ${ticker}`);
+    return res.json();
+  }
+
+  async searchSymbols(query: string, type?: string): Promise<SymbolInfo[]> {
+    const params = new URLSearchParams({ q: query });
+    if (type) params.set('type', type);
+    const res = await fetch(`${this.baseUrl}/symbols/search?${params}`);
+    return res.json();
+  }
+}
+```
+
+---
+
+## Integration with Chart
+
+```ts
+const chart = createChart(container, {
+  autoSize: true,
+  symbol: 'AAPL',
+  symbolResolver: new ApiSymbolResolver('https://api.example.com'),
+});
+
+// The chart uses the resolver for:
+// - Symbol search UI
+// - Price precision and formatting
+// - Timezone and exchange info
+```

--- a/stories/Docs/TouchGestures.mdx
+++ b/stories/Docs/TouchGestures.mdx
@@ -1,0 +1,98 @@
+import { Meta } from '@storybook/addon-docs/blocks';
+
+<Meta title="Docs/Touch Gestures" />
+
+# Touch Gestures
+
+fin-charter provides mobile touch gesture support through the `TouchGestureHandler` class, enabling pinch-to-zoom, two-finger pan, and momentum scrolling on touch devices.
+
+## `TouchGestureHandler`
+
+```ts
+import { TouchGestureHandler } from 'fin-charter';
+```
+
+The handler is automatically attached when the chart detects a touch-capable device. It translates multi-touch gestures into time-scale operations.
+
+---
+
+## Options
+
+```ts
+interface TouchGestureOptions {
+  pinchZoom?: boolean;         // default: true
+  twoFingerPan?: boolean;      // default: true
+  momentum?: boolean;          // default: true
+  momentumFriction?: number;   // default: 0.95 (0-1 range)
+}
+```
+
+### Configuring Touch Gestures
+
+```ts
+import { createChart } from 'fin-charter';
+
+const chart = createChart(container, {
+  autoSize: true,
+  touchGestures: {
+    pinchZoom: true,
+    twoFingerPan: true,
+    momentum: true,
+    momentumFriction: 0.95,
+  },
+});
+```
+
+---
+
+## Supported Gestures
+
+| Gesture | Action | Option |
+|---|---|---|
+| Pinch (two fingers) | Zoom in/out on the time axis | `pinchZoom` |
+| Two-finger drag | Pan the chart horizontally | `twoFingerPan` |
+| Flick release | Momentum scroll after pan | `momentum` |
+| Single tap | Show crosshair at tap position | Always enabled |
+| Long press | Open context menu | Always enabled |
+
+---
+
+## Pinch-to-Zoom
+
+When two fingers touch the chart, the handler calculates the distance between them. As the fingers move apart, the chart zooms in (increases `barSpacing`). Moving fingers together zooms out.
+
+```
+Initial pinch distance -> stored as reference
+Current pinch distance -> ratio applied to barSpacing
+```
+
+The zoom is centered on the midpoint between the two fingers.
+
+---
+
+## Momentum Scrolling
+
+After a two-finger pan, releasing with velocity triggers momentum scrolling. The `momentumFriction` parameter controls deceleration:
+
+- `0.99` = very smooth, long coast
+- `0.95` = default, natural feel
+- `0.85` = quick stop
+
+Momentum is cancelled when the user touches the chart again.
+
+---
+
+## Disabling Touch Gestures
+
+```ts
+const chart = createChart(container, {
+  autoSize: true,
+  touchGestures: {
+    pinchZoom: false,
+    twoFingerPan: false,
+    momentum: false,
+  },
+});
+```
+
+This leaves single-touch interactions (crosshair, tap) functional while disabling multi-touch gestures.

--- a/stories/Docs/TradingPrimitives.mdx
+++ b/stories/Docs/TradingPrimitives.mdx
@@ -1,0 +1,187 @@
+import { Meta } from '@storybook/addon-docs/blocks';
+
+<Meta title="Docs/Trading Primitives" />
+
+# Trading Primitives
+
+fin-charter provides `OrderLine` and `PositionLine` for displaying trading-specific information on charts. These extend price lines with trading semantics such as order side, quantity, drag-to-modify, and P&L calculation.
+
+## `OrderLine`
+
+Represents a pending order (limit, stop, or market) on the chart.
+
+```ts
+import { OrderLine } from 'fin-charter';
+import type { OrderLineOptions } from 'fin-charter';
+
+const order = new OrderLine({
+  price: 185.00,
+  quantity: 100,
+  side: 'buy',
+  orderType: 'limit',
+  color: '#26a69a',
+  lineStyle: 'dashed',
+  title: 'Buy Limit',
+  draggable: true,
+  axisLabelVisible: true,
+});
+```
+
+### `OrderLineOptions`
+
+```ts
+interface OrderLineOptions {
+  price: number;
+  quantity: number;
+  side: OrderSide;            // 'buy' | 'sell'
+  orderType: OrderType;       // 'limit' | 'stop' | 'market'
+  color?: string;             // default: '#2196F3'
+  lineWidth?: number;         // default: 1
+  lineStyle?: 'solid' | 'dashed' | 'dotted';  // default: 'dashed'
+  title?: string;
+  draggable?: boolean;        // default: true
+  axisLabelVisible?: boolean; // default: true
+}
+```
+
+### Modifying Orders
+
+```ts
+// Update price (e.g., after drag)
+order.setPrice(186.50);
+
+// Update quantity
+order.setQuantity(200);
+
+// Apply multiple option changes
+order.applyOptions({
+  price: 187.00,
+  color: '#FF9800',
+  lineStyle: 'solid',
+});
+
+// Cancel the order
+order.cancel();
+console.log(order.isCancelled); // true
+```
+
+### Event Callbacks
+
+```ts
+// Listen for modifications (price/quantity/options changes)
+order.onModified((o) => {
+  console.log('Order modified:', o.price, o.quantity);
+});
+
+// Listen for cancellation
+order.onCancelled((o) => {
+  console.log('Order cancelled:', o.id);
+});
+
+// Unsubscribe
+order.offModified(handler);
+order.offCancelled(handler);
+```
+
+### Serialization
+
+```ts
+const serialized = order.serialize();
+// { id, price, quantity, side, orderType, color, lineWidth, ... }
+```
+
+---
+
+## `PositionLine`
+
+Represents an open trading position with entry price and unrealized P&L calculation.
+
+```ts
+import { PositionLine } from 'fin-charter';
+import type { PositionLineOptions } from 'fin-charter';
+
+const position = new PositionLine({
+  entryPrice: 185.00,
+  quantity: 100,
+  side: 'buy',
+  color: '#26a69a',
+  title: 'Long AAPL',
+});
+```
+
+### `PositionLineOptions`
+
+```ts
+interface PositionLineOptions {
+  entryPrice: number;
+  quantity: number;
+  side: OrderSide;            // 'buy' | 'sell'
+  color?: string;             // default: green for buy, red for sell
+  lineWidth?: number;         // default: 1
+  lineStyle?: 'solid' | 'dashed' | 'dotted';  // default: 'solid'
+  title?: string;
+  axisLabelVisible?: boolean; // default: true
+}
+```
+
+### Unrealized P&L
+
+```ts
+const pnl = position.unrealizedPnL(190.00);
+// Buy position: (190 - 185) * 100 = 500.00
+
+const pnl2 = position.unrealizedPnL(180.00);
+// Buy position: (180 - 185) * 100 = -500.00
+```
+
+For sell (short) positions, the calculation is inverted: profit when price falls.
+
+---
+
+## Example: Order Entry Display
+
+```ts
+import { createChart, OrderLine, PositionLine } from 'fin-charter';
+
+const chart = createChart(container, { autoSize: true, symbol: 'AAPL' });
+const series = chart.addSeries({ type: 'candlestick' });
+series.setData(data);
+
+// Show existing position
+const position = new PositionLine({
+  entryPrice: 185.00,
+  quantity: 100,
+  side: 'buy',
+  title: 'Long 100 @ 185.00',
+});
+
+// Show pending orders
+const takeProfit = new OrderLine({
+  price: 200.00,
+  quantity: 100,
+  side: 'sell',
+  orderType: 'limit',
+  color: '#26a69a',
+  title: 'Take Profit',
+  draggable: true,
+});
+
+const stopLoss = new OrderLine({
+  price: 175.00,
+  quantity: 100,
+  side: 'sell',
+  orderType: 'stop',
+  color: '#ef5350',
+  title: 'Stop Loss',
+  draggable: true,
+});
+
+// React to drag modifications
+takeProfit.onModified((o) => {
+  console.log('Take profit moved to:', o.price);
+});
+
+stopLoss.onModified((o) => {
+  console.log('Stop loss moved to:', o.price);
+});
+```

--- a/stories/Docs/VolumeProfile.mdx
+++ b/stories/Docs/VolumeProfile.mdx
@@ -1,0 +1,151 @@
+import { Meta } from '@storybook/addon-docs/blocks';
+
+<Meta title="Docs/Volume Profile" />
+
+# Volume Profile
+
+The `computeVolumeProfile()` function generates a horizontal histogram of volume distributed by price level. It calculates the Point of Control (POC), Value Area High (VAH), and Value Area Low (VAL).
+
+## `computeVolumeProfile()`
+
+```ts
+import { computeVolumeProfile } from 'fin-charter/indicators/volume-profile';
+
+const result = computeVolumeProfile(store, fromIdx, toIdx, {
+  binCount: 24,
+  valueAreaPercent: 0.7,
+});
+```
+
+### Parameters
+
+| Parameter | Type | Description |
+|---|---|---|
+| `store` | `ColumnStore` | The bar data store |
+| `fromIdx` | `number` | Start bar index (inclusive) |
+| `toIdx` | `number` | End bar index (inclusive) |
+| `options` | `VolumeProfileOptions` | Configuration options |
+
+### `VolumeProfileOptions`
+
+```ts
+interface VolumeProfileOptions {
+  binCount?: number;          // default: 24
+  valueAreaPercent?: number;  // default: 0.7 (70%)
+}
+```
+
+---
+
+## Result
+
+```ts
+interface VolumeProfileResult {
+  bins: VolumeProfileBin[];
+  poc: number;          // Price level with highest volume
+  vah: number;          // Value Area High (upper bound of 70% volume)
+  val: number;          // Value Area Low (lower bound of 70% volume)
+  totalVolume: number;  // Total volume across all bins
+}
+```
+
+### `VolumeProfileBin`
+
+```ts
+interface VolumeProfileBin {
+  price: number;       // Center price of this bin
+  low: number;         // Bottom of bin
+  high: number;        // Top of bin
+  volume: number;      // Total volume
+  buyVolume: number;   // Volume where close >= open
+  sellVolume: number;  // Volume where close < open
+}
+```
+
+---
+
+## Key Levels
+
+### Point of Control (POC)
+
+The price level with the highest traded volume. This often acts as a magnet for price action.
+
+### Value Area High (VAH) / Value Area Low (VAL)
+
+The price range containing `valueAreaPercent` (default 70%) of total volume. The value area is built by expanding outward from the POC bin until the threshold is reached.
+
+---
+
+## Example
+
+```ts
+import { createChart } from 'fin-charter';
+import { computeVolumeProfile } from 'fin-charter/indicators/volume-profile';
+
+const chart = createChart(container, { autoSize: true, symbol: 'AAPL' });
+const series = chart.addSeries({ type: 'candlestick' });
+series.setData(data);
+
+// Compute volume profile for the visible range
+const store = series.getColumnStore();
+const vp = computeVolumeProfile(store, 0, store.length - 1, {
+  binCount: 30,
+  valueAreaPercent: 0.7,
+});
+
+console.log('POC:', vp.poc.toFixed(2));
+console.log('VAH:', vp.vah.toFixed(2));
+console.log('VAL:', vp.val.toFixed(2));
+console.log('Total volume:', vp.totalVolume);
+
+// Draw key levels as price lines
+series.createPriceLine({
+  price: vp.poc,
+  color: '#FF9800',
+  lineStyle: 'solid',
+  lineWidth: 2,
+  title: `POC ${vp.poc.toFixed(2)}`,
+});
+
+series.createPriceLine({
+  price: vp.vah,
+  color: '#26a69a',
+  lineStyle: 'dashed',
+  title: `VAH ${vp.vah.toFixed(2)}`,
+});
+
+series.createPriceLine({
+  price: vp.val,
+  color: '#ef5350',
+  lineStyle: 'dashed',
+  title: `VAL ${vp.val.toFixed(2)}`,
+});
+
+// Display bins
+vp.bins.forEach((bin) => {
+  console.log(
+    `${bin.low.toFixed(2)}-${bin.high.toFixed(2)}: ` +
+    `volume=${bin.volume}, buy=${bin.buyVolume}, sell=${bin.sellVolume}`
+  );
+});
+```
+
+---
+
+## Buy/Sell Volume Split
+
+Each bin tracks buy and sell volume separately:
+
+- **Buy volume**: bars where `close >= open` (bullish)
+- **Sell volume**: bars where `close < open` (bearish)
+
+This allows rendering the volume profile with a buy/sell color split for additional market insight.
+
+---
+
+## Edge Cases
+
+- If `fromIdx > toIdx` or the store is empty, returns `{ bins: [], poc: 0, vah: 0, val: 0, totalVolume: 0 }`
+- If all bars have the same price, a small margin is added to create valid bin boundaries
+- `binCount` is clamped to a minimum of 1
+- `valueAreaPercent` is clamped to the 0-1 range

--- a/stories/Features/AlertLines.stories.ts
+++ b/stories/Features/AlertLines.stories.ts
@@ -1,0 +1,186 @@
+import type { Meta, StoryObj } from '@storybook/html';
+import { createChart } from 'fin-charter';
+import { createChartContainer } from '../helpers';
+import { withDocs } from '../doc-renderer';
+import { AAPL_DAILY } from '../sample-data';
+
+const meta: Meta = {
+  title: 'Features/Alert Lines',
+  parameters: {
+    docs: {
+      description: {
+        component:
+          'Alert lines are price levels that fire callbacks when the current price crosses them. ' +
+          'They support armed/disarmed states, customizable trigger modes (crossing-up, crossing-down, crossing-either), ' +
+          'and can be dragged to adjust the price.',
+      },
+    },
+  },
+};
+export default meta;
+
+type Story = StoryObj;
+
+function makeButton(label: string, onClick: () => void): HTMLButtonElement {
+  const btn = document.createElement('button');
+  btn.textContent = label;
+  btn.style.cssText =
+    'padding: 6px 12px; margin-right: 6px; background: #2a2e39; color: #d1d4dc; ' +
+    'border: 1px solid #434651; border-radius: 4px; cursor: pointer; font-size: 13px;';
+  btn.addEventListener('click', onClick);
+  return btn;
+}
+
+export const ArmedAlert: Story = {
+  name: 'Armed & Disarmed',
+  parameters: {
+    docs: {
+      source: {
+        code: `import { createChart } from 'fin-charter';
+
+const chart = createChart(container, { autoSize: true, symbol: 'AAPL' });
+const series = chart.addSeries({ type: 'candlestick' });
+series.setData(data);
+
+const alert = chart.addAlertLine(190, {
+  color: '#FF9800',
+  lineStyle: 'dashed',
+  title: 'Alert @ 190',
+  triggerMode: 'crossing-either',
+  armed: true,
+});
+
+alert.onTriggered((a, direction) => {
+  console.log(\`Alert triggered: price crossed \${direction}\`);
+});
+
+// Disarm the alert
+alert.applyOptions({ armed: false });`,
+      },
+    },
+  },
+  render: () => {
+    const wrapper = document.createElement('div');
+    wrapper.style.cssText = 'display: flex; flex-direction: column; gap: 10px;';
+
+    const toolbar = document.createElement('div');
+    toolbar.style.cssText = 'display: flex; align-items: center; padding: 8px; background: #1e2235; border-radius: 4px;';
+
+    const status = document.createElement('span');
+    status.style.cssText = 'margin-left: 12px; color: #787b86; font-size: 13px; font-family: monospace;';
+    status.textContent = 'Alert is ARMED';
+
+    const container = createChartContainer();
+    const chart = createChart(container, { autoSize: true, symbol: 'AAPL' });
+    const series = chart.addSeries({ type: 'candlestick' });
+    series.setData(AAPL_DAILY);
+
+    const alert = chart.addAlertLine(190, {
+      color: '#FF9800',
+      lineStyle: 'dashed',
+      title: 'Alert @ 190',
+      triggerMode: 'crossing-either',
+      armed: true,
+    });
+
+    alert.onTriggered((_a, direction) => {
+      status.textContent = `Alert triggered! Price crossed ${direction}`;
+    });
+
+    const armBtn = makeButton('Arm', () => {
+      alert.applyOptions({ armed: true });
+      status.textContent = 'Alert is ARMED';
+    });
+
+    const disarmBtn = makeButton('Disarm', () => {
+      alert.applyOptions({ armed: false });
+      status.textContent = 'Alert is DISARMED';
+    });
+
+    toolbar.appendChild(armBtn);
+    toolbar.appendChild(disarmBtn);
+    toolbar.appendChild(status);
+    wrapper.appendChild(toolbar);
+    wrapper.appendChild(container);
+
+    const description = '<strong>Alert lines</strong> are price levels that fire callbacks when the current price crosses them. Use <code>chart.addAlertLine(price, options)</code> to create one. Each alert has an <code>armed</code> state &mdash; when disarmed, it remains visible but will not fire callbacks. Trigger modes include <code>crossing-up</code>, <code>crossing-down</code>, and <code>crossing-either</code>.';
+    const code = `const alert = chart.addAlertLine(190, {
+  color: '#FF9800',
+  lineStyle: 'dashed',
+  title: 'Alert @ 190',
+  triggerMode: 'crossing-either',
+  armed: true,
+});
+
+alert.onTriggered((a, direction) => {
+  console.log(\`Alert triggered: price crossed \${direction}\`);
+});
+
+// Toggle armed state
+alert.applyOptions({ armed: false });`;
+
+    return withDocs(wrapper, { description, code });
+  },
+};
+
+export const MultipleTriggerModes: Story = {
+  name: 'Trigger Modes',
+  parameters: {
+    docs: {
+      source: {
+        code: `chart.addAlertLine(185, {
+  triggerMode: 'crossing-up', color: '#22AB94', title: 'Cross Up',
+});
+chart.addAlertLine(195, {
+  triggerMode: 'crossing-down', color: '#F7525F', title: 'Cross Down',
+});
+chart.addAlertLine(190, {
+  triggerMode: 'crossing-either', color: '#FF9800', title: 'Cross Either',
+});`,
+      },
+    },
+  },
+  render: () => {
+    const container = createChartContainer();
+    const chart = createChart(container, { autoSize: true, symbol: 'AAPL' });
+    const series = chart.addSeries({ type: 'candlestick' });
+    series.setData(AAPL_DAILY);
+
+    chart.addAlertLine(185, {
+      color: '#22AB94',
+      lineStyle: 'dashed',
+      title: 'Cross Up',
+      triggerMode: 'crossing-up',
+      armed: true,
+    });
+
+    chart.addAlertLine(195, {
+      color: '#F7525F',
+      lineStyle: 'dashed',
+      title: 'Cross Down',
+      triggerMode: 'crossing-down',
+      armed: true,
+    });
+
+    chart.addAlertLine(190, {
+      color: '#FF9800',
+      lineStyle: 'dotted',
+      title: 'Cross Either',
+      triggerMode: 'crossing-either',
+      armed: true,
+    });
+
+    const description = 'Alert lines support three <strong>trigger modes</strong>: <code>crossing-up</code> fires only when price crosses upward, <code>crossing-down</code> fires only on downward crosses, and <code>crossing-either</code> fires in both directions. Combine multiple alert lines at different levels for comprehensive price monitoring.';
+    const code = `chart.addAlertLine(185, {
+  triggerMode: 'crossing-up', color: '#22AB94', title: 'Cross Up',
+});
+chart.addAlertLine(195, {
+  triggerMode: 'crossing-down', color: '#F7525F', title: 'Cross Down',
+});
+chart.addAlertLine(190, {
+  triggerMode: 'crossing-either', color: '#FF9800', title: 'Cross Either',
+});`;
+
+    return withDocs(container, { description, code });
+  },
+};

--- a/stories/Features/Export.stories.ts
+++ b/stories/Features/Export.stories.ts
@@ -1,0 +1,117 @@
+import type { Meta, StoryObj } from '@storybook/html';
+import { createChart } from 'fin-charter';
+import { createChartContainer } from '../helpers';
+import { withDocs } from '../doc-renderer';
+import { AAPL_DAILY } from '../sample-data';
+
+const meta: Meta = {
+  title: 'Features/Export',
+  parameters: {
+    docs: {
+      description: {
+        component:
+          'Export chart data and visuals in multiple formats: CSV for data, SVG for vector graphics, ' +
+          'and PDF for print-ready output.',
+      },
+    },
+  },
+};
+export default meta;
+
+type Story = StoryObj;
+
+function makeButton(label: string, onClick: () => void): HTMLButtonElement {
+  const btn = document.createElement('button');
+  btn.textContent = label;
+  btn.style.cssText =
+    'padding: 6px 12px; margin-right: 6px; background: #2a2e39; color: #d1d4dc; ' +
+    'border: 1px solid #434651; border-radius: 4px; cursor: pointer; font-size: 13px;';
+  btn.addEventListener('click', onClick);
+  return btn;
+}
+
+export const ExportFormats: Story = {
+  name: 'CSV, SVG & PDF Export',
+  parameters: {
+    docs: {
+      source: {
+        code: `import { createChart } from 'fin-charter';
+
+const chart = createChart(container, { autoSize: true, symbol: 'AAPL' });
+const series = chart.addSeries({ type: 'candlestick' });
+series.setData(data);
+
+// Export visible data as CSV
+const csv = chart.exportCSV({ separator: ',' });
+
+// Export chart as SVG string
+const svg = chart.exportSVG();
+
+// Export chart as PDF Blob
+const pdfBlob = chart.exportPDF({ title: 'AAPL Chart' });`,
+      },
+    },
+  },
+  render: () => {
+    const wrapper = document.createElement('div');
+    wrapper.style.cssText = 'display: flex; flex-direction: column; gap: 10px;';
+
+    const toolbar = document.createElement('div');
+    toolbar.style.cssText = 'display: flex; align-items: center; padding: 8px; background: #1e2235; border-radius: 4px;';
+
+    const output = document.createElement('pre');
+    output.style.cssText =
+      'max-height: 120px; overflow: auto; padding: 8px; background: #1a1b2e; ' +
+      'border: 1px solid #262840; border-radius: 4px; color: #d1d4dc; font-size: 12px; ' +
+      'font-family: monospace; display: none; white-space: pre-wrap;';
+
+    const container = createChartContainer();
+    const chart = createChart(container, { autoSize: true, symbol: 'AAPL' });
+    const series = chart.addSeries({ type: 'candlestick' });
+    series.setData(AAPL_DAILY);
+
+    const csvBtn = makeButton('Export CSV', () => {
+      const csv = chart.exportCSV({ separator: ',' });
+      output.textContent = csv.slice(0, 2000) + (csv.length > 2000 ? '\n...(truncated)' : '');
+      output.style.display = 'block';
+    });
+
+    const svgBtn = makeButton('Export SVG', () => {
+      const svg = chart.exportSVG();
+      output.textContent = svg.slice(0, 2000) + (svg.length > 2000 ? '\n...(truncated)' : '');
+      output.style.display = 'block';
+    });
+
+    const pdfBtn = makeButton('Export PDF', () => {
+      const blob = chart.exportPDF({ title: 'AAPL Daily Chart' });
+      output.textContent = `PDF Blob created: ${blob.size} bytes, type: ${blob.type}`;
+      output.style.display = 'block';
+    });
+
+    toolbar.appendChild(csvBtn);
+    toolbar.appendChild(svgBtn);
+    toolbar.appendChild(pdfBtn);
+    wrapper.appendChild(toolbar);
+    wrapper.appendChild(container);
+    wrapper.appendChild(output);
+
+    const description = 'Export chart content in three formats: <code>chart.exportCSV(options)</code> returns OHLCV data as a CSV string (with optional date range filtering and indicator columns), <code>chart.exportSVG()</code> returns a scalable vector graphics string, and <code>chart.exportPDF(options)</code> returns a PDF <code>Blob</code> for download or display.';
+    const code = `// CSV export with options
+const csv = chart.exportCSV({
+  separator: ',',
+  includeIndicators: true,
+  from: 1704067200,
+  to: 1709078400,
+});
+
+// SVG export
+const svg = chart.exportSVG();
+
+// PDF export
+const blob = chart.exportPDF({ title: 'AAPL Daily Chart' });
+const url = URL.createObjectURL(blob);
+window.open(url);`;
+
+    return withDocs(wrapper, { description, code });
+  },
+};

--- a/stories/Features/LogScale.stories.ts
+++ b/stories/Features/LogScale.stories.ts
@@ -1,0 +1,119 @@
+import type { Meta, StoryObj } from '@storybook/html';
+import { createChart } from 'fin-charter';
+import { createChartContainer } from '../helpers';
+import { withDocs } from '../doc-renderer';
+import { AAPL_DAILY } from '../sample-data';
+
+const meta: Meta = {
+  title: 'Features/Log Scale',
+  parameters: {
+    docs: {
+      description: {
+        component:
+          'Demonstrates switching between linear and logarithmic price scale modes. ' +
+          'Logarithmic scale is useful for long-term charts where percentage moves matter more than absolute moves.',
+      },
+    },
+  },
+};
+export default meta;
+
+type Story = StoryObj;
+
+function makeButton(label: string, onClick: () => void): HTMLButtonElement {
+  const btn = document.createElement('button');
+  btn.textContent = label;
+  btn.style.cssText =
+    'padding: 6px 12px; margin-right: 6px; background: #2a2e39; color: #d1d4dc; ' +
+    'border: 1px solid #434651; border-radius: 4px; cursor: pointer; font-size: 13px;';
+  btn.addEventListener('click', onClick);
+  return btn;
+}
+
+export const LinearVsLog: Story = {
+  name: 'Linear vs Logarithmic',
+  parameters: {
+    docs: {
+      source: {
+        code: `import { createChart } from 'fin-charter';
+
+// Linear scale (default)
+const chart = createChart(container, {
+  autoSize: true,
+  symbol: 'AAPL',
+  rightPriceScale: { mode: 'linear' },
+});
+
+// Switch to logarithmic
+chart.applyOptions({
+  rightPriceScale: { mode: 'logarithmic' },
+});`,
+      },
+    },
+  },
+  render: () => {
+    const wrapper = document.createElement('div');
+    wrapper.style.cssText = 'display: flex; flex-direction: column; gap: 10px;';
+
+    const toolbar = document.createElement('div');
+    toolbar.style.cssText = 'display: flex; align-items: center; padding: 8px; background: #1e2235; border-radius: 4px;';
+
+    const status = document.createElement('span');
+    status.style.cssText = 'margin-left: 12px; color: #787b86; font-size: 13px; font-family: monospace;';
+    status.textContent = 'Scale: linear';
+
+    const container = createChartContainer();
+    const chart = createChart(container, {
+      autoSize: true,
+      symbol: 'AAPL',
+      rightPriceScale: { mode: 'linear' },
+    });
+    const series = chart.addSeries({ type: 'candlestick' });
+    series.setData(AAPL_DAILY);
+
+    const linearBtn = makeButton('Linear', () => {
+      chart.applyOptions({ rightPriceScale: { mode: 'linear' } });
+      status.textContent = 'Scale: linear';
+      linearBtn.style.background = '#1a4a6b';
+      linearBtn.style.borderColor = '#2196F3';
+      logBtn.style.background = '#2a2e39';
+      logBtn.style.borderColor = '#434651';
+    });
+    linearBtn.style.background = '#1a4a6b';
+    linearBtn.style.borderColor = '#2196F3';
+
+    const logBtn = makeButton('Logarithmic', () => {
+      chart.applyOptions({ rightPriceScale: { mode: 'logarithmic' } });
+      status.textContent = 'Scale: logarithmic';
+      logBtn.style.background = '#1a4a6b';
+      logBtn.style.borderColor = '#2196F3';
+      linearBtn.style.background = '#2a2e39';
+      linearBtn.style.borderColor = '#434651';
+    });
+
+    toolbar.appendChild(linearBtn);
+    toolbar.appendChild(logBtn);
+    toolbar.appendChild(status);
+    wrapper.appendChild(toolbar);
+    wrapper.appendChild(container);
+
+    const description = 'Toggle between <strong>linear</strong> and <strong>logarithmic</strong> price scales using <code>chart.applyOptions({ rightPriceScale: { mode } })</code>. In logarithmic mode, equal vertical distances represent equal percentage changes rather than equal absolute price differences. This is particularly useful for assets with large price ranges or long time horizons.';
+    const code = `// Create with linear scale (default)
+const chart = createChart(container, {
+  autoSize: true,
+  rightPriceScale: { mode: 'linear' },
+});
+
+// Switch to logarithmic at runtime
+chart.applyOptions({
+  rightPriceScale: { mode: 'logarithmic' },
+});
+
+// Switch back to linear
+chart.applyOptions({
+  rightPriceScale: { mode: 'linear' },
+});`;
+
+    return withDocs(wrapper, { description, code });
+  },
+};

--- a/stories/Features/RangeSelection.stories.ts
+++ b/stories/Features/RangeSelection.stories.ts
@@ -1,0 +1,127 @@
+import type { Meta, StoryObj } from '@storybook/html';
+import { createChart } from 'fin-charter';
+import { createChartContainer } from '../helpers';
+import { withDocs } from '../doc-renderer';
+import { AAPL_DAILY } from '../sample-data';
+
+const meta: Meta = {
+  title: 'Features/Range Selection',
+  parameters: {
+    docs: {
+      description: {
+        component:
+          'Range selection allows users to drag-select a time range on the chart and view summary ' +
+          'statistics such as high, low, price change, percent change, bar count, and total volume.',
+      },
+    },
+  },
+};
+export default meta;
+
+type Story = StoryObj;
+
+function makeButton(label: string, onClick: () => void): HTMLButtonElement {
+  const btn = document.createElement('button');
+  btn.textContent = label;
+  btn.style.cssText =
+    'padding: 6px 12px; margin-right: 6px; background: #2a2e39; color: #d1d4dc; ' +
+    'border: 1px solid #434651; border-radius: 4px; cursor: pointer; font-size: 13px;';
+  btn.addEventListener('click', onClick);
+  return btn;
+}
+
+export const RangeMode: Story = {
+  name: 'Range Selection Mode',
+  parameters: {
+    docs: {
+      source: {
+        code: `import { createChart } from 'fin-charter';
+
+const chart = createChart(container, { autoSize: true, symbol: 'AAPL' });
+const series = chart.addSeries({ type: 'candlestick' });
+series.setData(data);
+
+// Enable range selection mode
+chart.setRangeSelectionActive(true);
+
+// Listen for selection results
+chart.onRangeSelected((stats) => {
+  if (stats) {
+    console.log('Bars:', stats.barCount);
+    console.log('Change:', stats.priceChange.toFixed(2));
+    console.log('Volume:', stats.totalVolume);
+  }
+});`,
+      },
+    },
+  },
+  render: () => {
+    const wrapper = document.createElement('div');
+    wrapper.style.cssText = 'display: flex; flex-direction: column; gap: 10px;';
+
+    const toolbar = document.createElement('div');
+    toolbar.style.cssText = 'display: flex; align-items: center; padding: 8px; background: #1e2235; border-radius: 4px;';
+
+    const status = document.createElement('span');
+    status.style.cssText = 'margin-left: 12px; color: #787b86; font-size: 13px; font-family: monospace;';
+    status.textContent = 'Click "Enable" then drag on the chart to select a range';
+
+    const container = createChartContainer();
+    const chart = createChart(container, { autoSize: true, symbol: 'AAPL' });
+    const series = chart.addSeries({ type: 'candlestick' });
+    series.setData(AAPL_DAILY);
+
+    chart.onRangeSelected((stats) => {
+      if (stats) {
+        status.textContent =
+          `Bars: ${stats.barCount} | Change: ${stats.priceChange.toFixed(2)} ` +
+          `(${stats.percentChange.toFixed(2)}%) | Volume: ${stats.totalVolume.toLocaleString()}`;
+      } else {
+        status.textContent = 'Selection cleared';
+      }
+    });
+
+    const enableBtn = makeButton('Enable Range Select', () => {
+      chart.setRangeSelectionActive(true);
+      status.textContent = 'Range selection active — drag on chart';
+      enableBtn.style.background = '#1a4a6b';
+      enableBtn.style.borderColor = '#2196F3';
+      disableBtn.style.background = '#2a2e39';
+      disableBtn.style.borderColor = '#434651';
+    });
+
+    const disableBtn = makeButton('Disable', () => {
+      chart.setRangeSelectionActive(false);
+      status.textContent = 'Range selection disabled';
+      disableBtn.style.background = '#1a4a6b';
+      disableBtn.style.borderColor = '#2196F3';
+      enableBtn.style.background = '#2a2e39';
+      enableBtn.style.borderColor = '#434651';
+    });
+
+    toolbar.appendChild(enableBtn);
+    toolbar.appendChild(disableBtn);
+    toolbar.appendChild(status);
+    wrapper.appendChild(toolbar);
+    wrapper.appendChild(container);
+
+    const description = '<strong>Range selection</strong> lets users drag-select a time range to view summary statistics. Call <code>chart.setRangeSelectionActive(true)</code> to enter selection mode, then subscribe via <code>chart.onRangeSelected(callback)</code>. The callback receives a <code>RangeSelectionStats</code> object with <code>barCount</code>, <code>priceChange</code>, <code>percentChange</code>, <code>totalVolume</code>, <code>high</code>, and <code>low</code>.';
+    const code = `// Enable range selection mode
+chart.setRangeSelectionActive(true);
+
+// Listen for selection results
+chart.onRangeSelected((stats) => {
+  if (stats) {
+    console.log('Bars:', stats.barCount);
+    console.log('Change:', stats.priceChange.toFixed(2));
+    console.log('Percent:', stats.percentChange.toFixed(2) + '%');
+    console.log('Volume:', stats.totalVolume);
+  }
+});
+
+// Disable range selection
+chart.setRangeSelectionActive(false);`;
+
+    return withDocs(wrapper, { description, code });
+  },
+};

--- a/stories/Features/TextLabels.stories.ts
+++ b/stories/Features/TextLabels.stories.ts
@@ -1,0 +1,110 @@
+import type { Meta, StoryObj } from '@storybook/html';
+import { createChart } from 'fin-charter';
+import { createChartContainer } from '../helpers';
+import { withDocs } from '../doc-renderer';
+import { AAPL_DAILY } from '../sample-data';
+
+const meta: Meta = {
+  title: 'Features/Text Labels',
+  parameters: {
+    docs: {
+      description: {
+        component:
+          'Text labels are lightweight annotations anchored to a time/price coordinate. ' +
+          'Use them to mark earnings dates, dividends, news events, or any point of interest.',
+      },
+    },
+  },
+};
+export default meta;
+
+type Story = StoryObj;
+
+export const EarningsAnnotations: Story = {
+  name: 'Earnings Annotations',
+  parameters: {
+    docs: {
+      source: {
+        code: `import { createChart } from 'fin-charter';
+
+const chart = createChart(container, { autoSize: true, symbol: 'AAPL' });
+const series = chart.addSeries({ type: 'candlestick' });
+series.setData(data);
+
+chart.addTextLabel(30, 194, 'Q1 Earnings', {
+  backgroundColor: 'rgba(33, 150, 243, 0.85)',
+  textColor: '#ffffff',
+  showConnector: true,
+  yOffset: -30,
+});
+
+chart.addTextLabel(120, 210, 'Q2 Earnings', {
+  backgroundColor: 'rgba(76, 175, 80, 0.85)',
+  textColor: '#ffffff',
+  showConnector: true,
+  yOffset: -30,
+});`,
+      },
+    },
+  },
+  render: () => {
+    const container = createChartContainer();
+    const chart = createChart(container, { autoSize: true, symbol: 'AAPL' });
+    const series = chart.addSeries({ type: 'candlestick' });
+    series.setData(AAPL_DAILY);
+
+    chart.addTextLabel(30, AAPL_DAILY[30].high + 2, 'Q1 Earnings', {
+      backgroundColor: 'rgba(33, 150, 243, 0.85)',
+      textColor: '#ffffff',
+      fontSize: 11,
+      showConnector: true,
+      yOffset: -30,
+      borderRadius: 4,
+      padding: 6,
+    });
+
+    chart.addTextLabel(120, AAPL_DAILY[120].high + 2, 'Q2 Earnings', {
+      backgroundColor: 'rgba(76, 175, 80, 0.85)',
+      textColor: '#ffffff',
+      fontSize: 11,
+      showConnector: true,
+      yOffset: -30,
+      borderRadius: 4,
+      padding: 6,
+    });
+
+    chart.addTextLabel(75, AAPL_DAILY[75].low - 2, 'Dividend Ex-Date', {
+      backgroundColor: 'rgba(156, 39, 176, 0.85)',
+      textColor: '#ffffff',
+      fontSize: 11,
+      showConnector: true,
+      yOffset: 30,
+      borderRadius: 4,
+      padding: 6,
+    });
+
+    const description = '<strong>Text labels</strong> are programmatic annotations anchored to a bar index and price coordinate. Use <code>chart.addTextLabel(barIndex, price, text, options)</code> to place them. They survive zoom/pan and are included in screenshot exports. Options include <code>backgroundColor</code>, <code>textColor</code>, <code>showConnector</code>, <code>yOffset</code>, and <code>boxAnchor</code>.';
+    const code = `chart.addTextLabel(30, data[30].high + 2, 'Q1 Earnings', {
+  backgroundColor: 'rgba(33, 150, 243, 0.85)',
+  textColor: '#ffffff',
+  showConnector: true,
+  yOffset: -30,
+});
+
+chart.addTextLabel(120, data[120].high + 2, 'Q2 Earnings', {
+  backgroundColor: 'rgba(76, 175, 80, 0.85)',
+  textColor: '#ffffff',
+  showConnector: true,
+  yOffset: -30,
+});
+
+chart.addTextLabel(75, data[75].low - 2, 'Dividend Ex-Date', {
+  backgroundColor: 'rgba(156, 39, 176, 0.85)',
+  textColor: '#ffffff',
+  showConnector: true,
+  yOffset: 30,
+});`;
+
+    return withDocs(container, { description, code });
+  },
+};

--- a/stories/Features/UndoRedo.stories.ts
+++ b/stories/Features/UndoRedo.stories.ts
@@ -1,0 +1,146 @@
+import type { Meta, StoryObj } from '@storybook/html';
+import { createChart } from 'fin-charter';
+import { createChartContainer } from '../helpers';
+import { withDocs } from '../doc-renderer';
+import { AAPL_DAILY } from '../sample-data';
+
+const meta: Meta = {
+  title: 'Features/Undo Redo',
+  parameters: {
+    docs: {
+      description: {
+        component:
+          'Built-in undo/redo support for drawing operations. ' +
+          'Uses a command pattern with configurable stack depth. ' +
+          'Keyboard shortcuts Ctrl+Z / Ctrl+Shift+Z are supported by default.',
+      },
+    },
+  },
+};
+export default meta;
+
+type Story = StoryObj;
+
+function makeButton(label: string, onClick: () => void): HTMLButtonElement {
+  const btn = document.createElement('button');
+  btn.textContent = label;
+  btn.style.cssText =
+    'padding: 6px 12px; margin-right: 6px; background: #2a2e39; color: #d1d4dc; ' +
+    'border: 1px solid #434651; border-radius: 4px; cursor: pointer; font-size: 13px;';
+  btn.addEventListener('click', onClick);
+  return btn;
+}
+
+export const UndoRedoDrawings: Story = {
+  name: 'Undo & Redo Drawings',
+  parameters: {
+    docs: {
+      source: {
+        code: `import { createChart } from 'fin-charter';
+
+const chart = createChart(container, { autoSize: true, symbol: 'AAPL' });
+const series = chart.addSeries({ type: 'candlestick' });
+series.setData(data);
+
+// Draw something
+chart.addDrawing('horizontal-line',
+  [{ time: data[50].time, price: 190 }],
+  { color: '#2196F3', lineWidth: 1 },
+);
+
+// Undo last drawing
+chart.undo();
+
+// Redo
+chart.redo();`,
+      },
+    },
+  },
+  render: () => {
+    const wrapper = document.createElement('div');
+    wrapper.style.cssText = 'display: flex; flex-direction: column; gap: 10px;';
+
+    const toolbar = document.createElement('div');
+    toolbar.style.cssText = 'display: flex; align-items: center; padding: 8px; background: #1e2235; border-radius: 4px;';
+
+    const status = document.createElement('span');
+    status.style.cssText = 'margin-left: 12px; color: #787b86; font-size: 13px; font-family: monospace;';
+    status.textContent = 'Add drawings, then use Undo/Redo';
+
+    const container = createChartContainer();
+    const chart = createChart(container, { autoSize: true, symbol: 'AAPL' });
+    const series = chart.addSeries({ type: 'candlestick' });
+    series.setData(AAPL_DAILY);
+
+    let drawingCount = 0;
+
+    const addDrawingBtn = makeButton('Add Horizontal Line', () => {
+      const price = 180 + Math.random() * 30;
+      chart.addDrawing(
+        'horizontal-line',
+        [{ time: AAPL_DAILY[50].time, price }],
+        { color: '#2196F3', lineWidth: 1, lineDash: [4, 4] },
+      );
+      drawingCount++;
+      status.textContent = `Added line at ${price.toFixed(2)} (${drawingCount} drawing${drawingCount !== 1 ? 's' : ''})`;
+    });
+
+    const addTrendBtn = makeButton('Add Trendline', () => {
+      const startIdx = Math.floor(Math.random() * 100);
+      const endIdx = startIdx + 30 + Math.floor(Math.random() * 50);
+      chart.addDrawing(
+        'trendline',
+        [
+          { time: AAPL_DAILY[startIdx].time, price: AAPL_DAILY[startIdx].low },
+          { time: AAPL_DAILY[Math.min(endIdx, AAPL_DAILY.length - 1)].time, price: AAPL_DAILY[Math.min(endIdx, AAPL_DAILY.length - 1)].high },
+        ],
+        { color: '#22AB94', lineWidth: 2 },
+      );
+      drawingCount++;
+      status.textContent = `Added trendline (${drawingCount} drawing${drawingCount !== 1 ? 's' : ''})`;
+    });
+
+    const undoBtn = makeButton('Undo (Ctrl+Z)', () => {
+      const ok = chart.undo();
+      if (ok) {
+        drawingCount = Math.max(0, drawingCount - 1);
+        status.textContent = `Undo performed (${drawingCount} drawing${drawingCount !== 1 ? 's' : ''})`;
+      } else {
+        status.textContent = 'Nothing to undo';
+      }
+    });
+
+    const redoBtn = makeButton('Redo (Ctrl+Shift+Z)', () => {
+      const ok = chart.redo();
+      if (ok) {
+        drawingCount++;
+        status.textContent = `Redo performed (${drawingCount} drawing${drawingCount !== 1 ? 's' : ''})`;
+      } else {
+        status.textContent = 'Nothing to redo';
+      }
+    });
+
+    toolbar.appendChild(addDrawingBtn);
+    toolbar.appendChild(addTrendBtn);
+    toolbar.appendChild(undoBtn);
+    toolbar.appendChild(redoBtn);
+    toolbar.appendChild(status);
+    wrapper.appendChild(toolbar);
+    wrapper.appendChild(container);
+
+    const description = '<strong>Undo/Redo</strong> is built into the chart for all drawing operations. Use <code>chart.undo()</code> and <code>chart.redo()</code> programmatically, or press <code>Ctrl+Z</code> / <code>Ctrl+Shift+Z</code>. The internal <code>UndoRedoManager</code> implements a command pattern with a configurable max depth (default 50).';
+    const code = `// Add a drawing
+chart.addDrawing('horizontal-line',
+  [{ time: data[50].time, price: 190 }],
+  { color: '#2196F3', lineWidth: 1 },
+);
+
+// Undo last operation
+chart.undo(); // returns true if successful
+
+// Redo last undone operation
+chart.redo(); // returns true if successful`;
+
+    return withDocs(wrapper, { description, code });
+  },
+};

--- a/stories/Features/WebGLRenderer.stories.ts
+++ b/stories/Features/WebGLRenderer.stories.ts
@@ -1,0 +1,82 @@
+import type { Meta, StoryObj } from '@storybook/html';
+import { createChart, isWebGLAvailable } from 'fin-charter';
+import { createChartContainer, generateOHLCV } from '../helpers';
+import { withDocs } from '../doc-renderer';
+
+const meta: Meta = {
+  title: 'Features/WebGL Renderer',
+  parameters: {
+    docs: {
+      description: {
+        component:
+          'Demonstrates WebGL rendering mode for high-performance charting. ' +
+          'When available, WebGL accelerates rendering of candlestick, line, and area series. ' +
+          'Falls back to Canvas2D automatically if WebGL is not supported.',
+      },
+    },
+  },
+};
+export default meta;
+
+type Story = StoryObj;
+
+export const WebGLMode: Story = {
+  name: 'WebGL Rendering',
+  parameters: {
+    docs: {
+      source: {
+        code: `import { createChart, isWebGLAvailable } from 'fin-charter';
+
+console.log('WebGL available:', isWebGLAvailable());
+
+const chart = createChart(container, {
+  autoSize: true,
+  symbol: 'AAPL',
+  renderer: 'webgl', // falls back to 'canvas2d' if unavailable
+});
+
+const series = chart.addSeries({ type: 'candlestick' });
+series.setData(largeDataset); // 5000 bars`,
+      },
+    },
+  },
+  render: () => {
+    const wrapper = document.createElement('div');
+    wrapper.style.cssText = 'display: flex; flex-direction: column; gap: 10px;';
+
+    const infoBar = document.createElement('div');
+    infoBar.style.cssText = 'padding: 8px 12px; background: #1e2235; border-radius: 4px; color: #d1d4dc; font-size: 13px; font-family: monospace;';
+    infoBar.textContent = `WebGL available: ${isWebGLAvailable()} | Rendering 5,000 bars`;
+
+    const container = createChartContainer();
+    const chart = createChart(container, {
+      autoSize: true,
+      symbol: 'PERF',
+      renderer: 'webgl',
+    });
+
+    const data = generateOHLCV(5000, 100, 1609459200);
+    const series = chart.addSeries({ type: 'candlestick' });
+    series.setData(data);
+
+    wrapper.appendChild(infoBar);
+    wrapper.appendChild(container);
+
+    const description = '<strong>WebGL rendering</strong> uses GPU-accelerated drawing for supported series types (candlestick, line, area). Set <code>renderer: \'webgl\'</code> in chart options. Use <code>isWebGLAvailable()</code> to check browser support. The chart falls back to <code>canvas2d</code> automatically if WebGL is unavailable. WebGL excels with large datasets (5,000+ bars).';
+    const code = `import { createChart, isWebGLAvailable } from 'fin-charter';
+
+// Check availability
+console.log('WebGL available:', isWebGLAvailable());
+
+// Create chart with WebGL renderer
+const chart = createChart(container, {
+  autoSize: true,
+  renderer: 'webgl',
+});
+
+const series = chart.addSeries({ type: 'candlestick' });
+series.setData(largeDataset);`;
+
+    return withDocs(wrapper, { description, code });
+  },
+};


### PR DESCRIPTION
## Summary
- Add 7 interactive stories (TypeScript) for alert lines, text labels, range selection, undo/redo, log scale, WebGL renderer, and CSV/SVG/PDF export
- Add 13 MDX documentation pages covering data feed, custom indicators, storage adapters, accessibility, touch gestures, CSS theming, chart sync, replay mode, symbol resolver, trading primitives, volume profile, RTL support, and plugin system
- All stories follow existing patterns using `createChartContainer`, `AAPL_DAILY`, `withDocs`, and the standard Meta/StoryObj pattern

## Test plan
- [ ] Verify `npx tsc --noEmit` passes (verified locally)
- [ ] Verify `npm run build` passes (verified locally)
- [ ] Run Storybook locally and check each new story renders correctly
- [ ] Verify MDX pages render with proper formatting in Storybook Docs tab
- [ ] Check that all code examples in MDX pages use correct import paths

🤖 Generated with [Claude Code](https://claude.com/claude-code)