### PR TITLE
infra: switch to npm trusted publishing (OIDC)

### DIFF
--- a/.github/workflows/publish-manual.yml
+++ b/.github/workflows/publish-manual.yml
@@ -42,9 +42,7 @@ jobs:
         run: npm version ${{ github.event.inputs.version }} --no-git-tag-version
 
       - name: Publish
-        run: npm publish --provenance --access public --tag ${{ github.event.inputs.tag }}
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: npm publish --provenance --tag ${{ github.event.inputs.tag }}
 
       - name: Create Git tag
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,13 +41,9 @@ jobs:
         with:
           # When changesets are present: creates a "Version Packages" PR
           # When no changesets remain (PR was merged): publishes to npm
-          publish: npm publish --provenance --access public
+          publish: npm publish --provenance
           version: npx changeset version
           title: 'chore: version packages'
           commit: 'chore: version packages'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          # Trusted publishing: npm uses the OIDC id-token to authenticate.
-          # No NPM_TOKEN secret needed — configure the trusted publisher on npmjs.com instead.
-          # Fallback: if NPM_TOKEN secret is set, it will be used as NODE_AUTH_TOKEN.
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
## Summary

Switch from token-based npm auth to OIDC trusted publishing:
- No stored secrets needed (no OTP issues with 2FA)
- Short-lived tokens generated per workflow run
- `--provenance` flag included for supply chain security

## Setup required on npmjs.com

1. Go to [npmjs.com](https://www.npmjs.com) → package `@itssumitrai/fin-charter` → **Settings** → **Trusted Publishers**
2. Click **Add new trusted publisher**
3. Fill in:
   - **Repository owner**: `itssumitrai`
   - **Repository name**: `fin-charter`
   - **Workflow filename**: `release.yml`
   - **Environment**: *(leave blank)*
4. Repeat for `publish-manual.yml` if you want manual releases too

After that, the NPM_TOKEN secret can be removed from the repository.

🤖 Generated with [Claude Code](https://claude.com/claude-code)