### PR TITLE
fix: auto-fit uses correct container width, infinite scroll fallback

### DIFF
--- a/dev/components/AdvancedChart.svelte
+++ b/dev/components/AdvancedChart.svelte
@@ -180,7 +180,8 @@
       if (range.from <= firstBarTime) {
         isFetchingHistory = true;
         try {
-          const result = await fetchMoreBars(appStore.symbol, appStore.periodicity, firstBarTime, firstTradeDate);
+          const firstBarPrice = allBars[0].open;
+          const result = await fetchMoreBars(appStore.symbol, appStore.periodicity, firstBarTime, firstTradeDate, firstBarPrice);
           // Guard: only apply if symbol/periodicity haven't changed while fetching
           if (result.bars.length > 0 && mainSeries && allBars.length > 0 && allBars[0].time === firstBarTime) {
             allBars = [...result.bars, ...allBars];

--- a/dev/data/yahoo-finance.ts
+++ b/dev/data/yahoo-finance.ts
@@ -79,6 +79,9 @@ const REQUEST_CHUNK: Record<string, number> = {
  */
 const fetchedRanges = new Map<string, { period1: number; period2: number; lastRequest: number }>();
 
+/** Track whether the proxy is available (set to false on first fetch failure). */
+let proxyAvailable = true;
+
 function periodicityToKey(p: Periodicity): string {
   const map: Record<string, string> = {
     minute: 'm', hour: 'h', day: 'D', week: 'W', month: 'M',
@@ -141,10 +144,12 @@ export async function fetchBars(
     resp = await fetch(url);
   } catch {
     // Proxy unavailable (e.g. static Storybook build) — return generated fallback data
+    proxyAvailable = false;
     return generateFallbackData(symbol);
   }
   if (!resp.ok) {
     // Proxy endpoint unavailable (e.g. static Storybook build) — fallback
+    proxyAvailable = false;
     return generateFallbackData(symbol);
   }
 
@@ -275,6 +280,7 @@ export async function fetchMoreBars(
   periodicity: Periodicity,
   beforeTimestamp: number,
   firstTradeDate?: number,
+  startPrice?: number,
 ): Promise<FetchMoreResult> {
   const key = periodicityToKey(periodicity);
   const chunkSize = REQUEST_CHUNK[key] ?? 0;
@@ -282,6 +288,19 @@ export async function fetchMoreBars(
 
   const yahooInterval = (INTERVAL_MAP[key] ?? INTERVAL_MAP['1D']).interval;
   const rangeKey = `${symbol}:${key}`;
+
+  // If proxy is unavailable, generate synthetic historical data so the chart
+  // supports infinite scroll even in static builds (e.g. deployed Storybook)
+  if (!proxyAvailable) {
+    const intervalMap: Record<string, number> = {
+      '1m': 60, '5m': 300, '15m': 900, '1h': 3600, '4h': 14400,
+      '1D': 86400, '1W': 604800, '1M': 2592000,
+    };
+    const intervalSec = intervalMap[key] ?? 86400;
+    const count = Math.min(200, Math.floor(chunkSize / intervalSec));
+    const bars = generatePrecedingBars(beforeTimestamp, startPrice ?? 100, count, intervalSec);
+    return { bars, moreAvailable: true };
+  }
 
   // Check if we already have this range cached (debounce within 30s)
   const cached = fetchedRanges.get(rangeKey);
@@ -366,6 +385,7 @@ export async function fetchMoreBars(
 /** Clear cached fetch ranges (call on symbol/periodicity change). */
 export function clearFetchCache(): void {
   fetchedRanges.clear();
+  proxyAvailable = true; // re-check proxy on next fetch
 }
 
 // Fallback data for static builds (no proxy available)
@@ -395,6 +415,33 @@ function generateFallbackData(symbol: string): { bars: Bar[]; meta: QuoteMeta } 
     bars,
     meta: { price, previousClose: startPrice, currency: 'USD', exchange: 'NAS', timezone: 'America/New_York', firstTradeDate: 0 },
   };
+}
+
+/**
+ * Generate synthetic historical bars preceding `beforeTimestamp`.
+ * The first bar's close matches `startPrice` so the data connects seamlessly.
+ */
+function generatePrecedingBars(
+  beforeTimestamp: number,
+  startPrice: number,
+  count: number,
+  intervalSec: number,
+): Bar[] {
+  const bars: Bar[] = [];
+  let price = startPrice;
+  // Walk backwards from beforeTimestamp
+  for (let i = count; i >= 1; i--) {
+    const time = beforeTimestamp - i * intervalSec;
+    const change = price * (Math.random() * 0.04 - 0.02);
+    const open = Math.max(0.01, price - change);
+    const close = price;
+    const high = Math.max(open, close) + Math.random() * price * 0.015;
+    const low = Math.max(0.01, Math.min(open, close) - Math.random() * price * 0.015);
+    const volume = Math.round(1e6 + Math.random() * 9e6);
+    bars.push({ time, open, high, low, close, volume });
+    price = open; // walk price backwards
+  }
+  return bars;
 }
 
 function aggregate4h(bars: Bar[]): Bar[] {

--- a/src/api/chart-api.ts
+++ b/src/api/chart-api.ts
@@ -1029,6 +1029,15 @@ class ChartApi implements IChartApi {
     this._options.width = width;
     this._options.height = height;
 
+    // Auto-fit on first resize with data (autoSize charts get correct width here)
+    if (!this._hasAutoFit && this._series.length > 0) {
+      const store = this._series[0].api.getDataLayer().store;
+      if (store.length > 0) {
+        this._hasAutoFit = true;
+        this._timeScale.fitContent();
+      }
+    }
+
     this._layoutPanes();
     this.requestRepaint(InvalidationLevel.Full);
 
@@ -2178,8 +2187,9 @@ class ChartApi implements IChartApi {
       const primaryStore = this._series[0].api.getDataLayer().store;
       this._timeScale.setDataLength(primaryStore.length);
 
-      // Auto-fit content on first paint with data so the chart fills the viewport
-      if (!this._hasAutoFit && primaryStore.length > 0 && this._chartWidth > 0) {
+      // Auto-fit content on first paint with data (non-autoSize charts only;
+      // autoSize charts auto-fit in resize() once the container has real dimensions)
+      if (!this._hasAutoFit && !this._options.autoSize && primaryStore.length > 0 && this._chartWidth > 0) {
         this._hasAutoFit = true;
         this._timeScale.fitContent();
       }


### PR DESCRIPTION
## Summary

- **Auto-fit fix**: For `autoSize` charts, `fitContent()` now runs in `resize()` (after the container has real dimensions) instead of `_paint()` (which used the default 800px width). This eliminates gaps on left/right in all Storybook stories. Non-autoSize charts still auto-fit in `_paint()`.
- **Infinite scroll fallback**: When the Yahoo Finance proxy is unavailable (deployed Storybook on GitHub Pages), `fetchMoreBars()` generates synthetic preceding bars so the Advanced Chart supports infinite left-scroll even without a live API.
- **Proxy tracking**: `proxyAvailable` flag is set to false on first fetch failure, and reset on symbol/periodicity change so re-detection works.

## Test plan

- [x] All 1478 tests pass
- [x] Library + dev app build succeeds
- [ ] Verify no left/right gaps in Candlestick, Line, Area, Bar chart stories
- [ ] Verify Advanced Chart supports infinite left-scroll in deployed Storybook
- [ ] Verify Advanced Chart loads real Yahoo data when proxy is available (local dev)

🤖 Generated with [Claude Code](https://claude.com/claude-code)